### PR TITLE
Remove Tradeshift globals and env

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -1,21 +1,5 @@
 {
 	"extends": "standard",
-	"env": {
-		"es6": true,
-		"browser": true,
-		"node": true,
-		"jasmine": true
-	},
-	"globals": {
-		"t": true,
-		"ts": true,
-		"gui": true,
-		"app": true,
-		"__app": true,
-		"__config": true,
-		"runtime": true,
-		"server": true
-	},
 	"rules": {
 		"array-bracket-spacing": [2, "never"],
 		"block-scoped-var": 2,

--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
 		"url": "https://github.com/Tradeshift/eslint-config-tradeshift/issues"
 	},
 	"devDependencies": {
-		"eslint": "^3.1.1",
+		"eslint": ">=3.8.1",
 		"eslint-config-standard": "^6.2.0",
-		"eslint-plugin-promise": "^2.0.0",
-		"eslint-plugin-standard": "^2.0.0",
+		"eslint-plugin-promise": ">=3.3.0",
+		"eslint-plugin-standard": ">=2.0.0",
 		"tape": "^4.6.0"
 	},
 	"homepage": "https://github.com/Tradeshift/eslint-config-tradeshift",
@@ -49,8 +49,9 @@
 	"license": "ISC",
 	"main": "index.js",
 	"peerDependencies": {
-		"eslint": ">=3.0.0",
-		"eslint-config-standard": ">=6.2.0"
+		"eslint": ">=3.8.1",
+		"eslint-plugin-promise": ">=3.3.0",
+		"eslint-plugin-standard": ">=2.0.0"
 	},
 	"repository": {
 		"type": "git",

--- a/test/basic.js
+++ b/test/basic.js
@@ -3,8 +3,6 @@ var test = require('tape');
 
 test('test basic properties of config', function(t) {
 	t.ok(isString(config.extends));
-	t.ok(isObject(config.env));
-	t.ok(isObject(config.globals));
 	t.ok(isObject(config.rules));
 	t.end();
 });


### PR DESCRIPTION
Remove opinionated env and globals.

[eslint-config-standard](https://github.com/feross/eslint-config-standard/blob/c879dfb71e03739a45e980687f9a28c94b4a95d2/eslintrc.json#L11-L25) already has some.

```
  "env": {
    "es6": true,
    "node": true
  },

  "globals": {
    "document": false,
    "navigator": false,
    "window": false
  },
```