### PR TITLE
enabled "quotes" rule to enforce single-quotes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,10 +8,20 @@
 		"dot-notation": "error",
 		"guard-for-in": "error",
 		"handle-callback-err": "error",
-		"no-empty": ["error", { "allowEmptyCatch": true }],
+		"no-empty": [
+			"error",
+			{
+				"allowEmptyCatch": true
+			}
+		],
 		"no-loop-func": "error",
 		"no-script-url": "error",
 		"no-tabs": "off",
+		"quotes": [
+			"error",
+			"single",
+			"avoid-escape"
+		],
 		"standard/computed-property-even-spacing": "off"
 	}
 }


### PR DESCRIPTION
eslint defaults to double-quotes, so suggesting this fix to enforce single-quotes, to prevent IDEs with auto-fix from replacing all single-quotes with double-quotes.

http://eslint.org/docs/2.0.0/rules/quotes

NOTE: a few lines were re-formatted by Prettier.

@tstapleton @sampi @jverducci 