### PR TITLE
Fixed formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,45 +33,44 @@ To use the JavaScript Tradeshift Style shareable config, you'll need `eslint-con
 
 1. Install the correct versions of each package, which are listed by the command:
 
-  ```sh
-  npm info "eslint-config-tradeshift@latest" peerDependencies
-  ```
+    ```sh
+    npm info "eslint-config-tradeshift@latest" peerDependencies
+    ```
 
-  Linux/OSX users can run
+    Linux/OSX users can run
 
-  ```sh
-  (
-    export PKG=eslint-config-tradeshift;
-    npm info "$PKG@latest" peerDependencies --json | command sed 's/[\{\},]//g ; s/: /@/g' | xargs npm install --save-dev "$PKG@latest"
-  )
-  ```
+    ```sh
+    (
+      export PKG=eslint-config-tradeshift;
+      npm info "$PKG@latest" peerDependencies --json | command sed 's/[\{\},]//g ; s/: /@/g' | xargs npm install --save-dev "$PKG@latest"
+    )
+    ```
 
-  Which produces and runs a command like:
+    Which produces and runs a command like:
 
-  ```sh
-  npm install  --save-dev eslint-config-tradeshift eslint-config-prettier@^#.#.# eslint-config-standard@^#.#.# eslint-plugin-import@^#.#.# eslint-plugin-node@^#.#.# eslint-plugin-promise@^#.#.# eslint-plugin-standard@^#.#.#
-  ```
+    ```sh
+    npm install  --save-dev eslint-config-tradeshift eslint-config-prettier@^#.#.# eslint-config-standard@^#.#.# eslint-plugin-import@^#.#.# eslint-plugin-node@^#.#.# eslint-plugin-promise@^#.#.# eslint-plugin-standard@^#.#.#
+    ```
 
-  Windows users can either install all the peer dependencies manually, or use the [install-peerdeps](https://github.com/nathanhleung/install-peerdeps) cli tool.
+    Windows users can either install all the peer dependencies manually, or use the [install-peerdeps](https://github.com/nathanhleung/install-peerdeps) cli tool.
 
-  ```sh
-  npm install -g install-peerdeps
-  install-peerdeps --dev eslint-config-tradeshift
-  ```
+    ```sh
+    npm install -g install-peerdeps
+    install-peerdeps --dev eslint-config-tradeshift
+    ```
 
-  The cli will produce and run a command like:
+    The cli will produce and run a command like:
 
-  ```sh
-  npm install  --save-dev eslint-config-tradeshift eslint-config-prettier@^#.#.# eslint-config-standard@^#.#.# eslint-plugin-import@^#.#.# eslint-plugin-node@^#.#.# eslint-plugin-promise@^#.#.# eslint-plugin-standard@^#.#.#
+    ```sh
+    npm install  --save-dev eslint-config-tradeshift eslint-config-prettier@^#.#.# eslint-config-standard@^#.#.# eslint-plugin-import@^#.#.# eslint-plugin-node@^#.#.# eslint-plugin-promise@^#.#.# eslint-plugin-standard@^#.#.#
     ```
 
 2. Add `"extends": "tradeshift"` to your .eslintrc
 
+    *Note: We omitted the `eslint-config-` prefix since it is automatically assumed by ESLint.*
 
-*Note: We omitted the `eslint-config-` prefix since it is automatically assumed by ESLint.*
-
-You can override settings from the shareable config by adding them directly into your
-`.eslintrc` file.
+    You can override settings from the shareable config by adding them directly into your
+    `.eslintrc` file.
 
 ## Thanks
 


### PR DESCRIPTION
Fixed two issues:
1) Part of the instructions (see number 2) displaying in a codeblock.
2) Added indent so instructions align with the number they fall under.

@sampi 