### PR TITLE
Add babel-eslint for better syntax support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,3 @@ end_of_line = lf
 charset = UTF-8
 trim_trailing_whitespace = true
 insert_final_newline = true
-
-[package.json]
-indent_style = space
-

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,8 +1,6 @@
 {
-	"extends": [
-		"standard",
-		"prettier"
-	],
+	"parser": "babel-eslint",
+	"extends": ["standard", "prettier"],
 	"rules": {
 		"block-scoped-var": "error",
 		"dot-notation": "error",
@@ -17,11 +15,7 @@
 		"no-loop-func": "error",
 		"no-script-url": "error",
 		"no-tabs": "off",
-		"quotes": [
-			"error",
-			"single",
-			"avoid-escape"
-		],
+		"quotes": ["error", "single", "avoid-escape"],
 		"standard/computed-property-even-spacing": "off"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 		"url": "https://github.com/Tradeshift/eslint-config-tradeshift/issues"
 	},
 	"dependencies": {
+		"babel-eslint": "^8.2.3",
 		"eslint-config-prettier": "2.9.0",
 		"eslint-config-standard": "11.0.0",
 		"eslint-plugin-import": "2.12.0",
@@ -62,6 +63,7 @@
 	},
 	"scripts": {
 		"test": "tape test/*.js",
+		"lint": "eslint .",
 		"prettier-check": "eslint --print-config .eslintrc.js | eslint-config-prettier-check"
 	}
 }

--- a/test/validate-config.js
+++ b/test/validate-config.js
@@ -9,8 +9,17 @@ test('load config in eslint to validate all rule syntax is correct', function(t)
 		configFile: '.eslintrc.json'
 	});
 
-	var code = 'var foo = 1;\nvar bar = function() {};\nbar(foo);\n';
+	var code = `
+	var foo = 1;
+	var bar = function() {};
+	bar(foo);
 
-	t.equal(cli.executeOnText(code).errorCount, 0);
+	class MyClass {
+		static propTypes = {}
+	}
+	bar(new MyClass());
+	`;
+
+	t.deepEqual(cli.executeOnText(code).results[0].messages, []);
 	t.end();
 });


### PR DESCRIPTION
The missing features were found during a refactoring involving static class properties.

```js
class MyReactComponent {
	static propTypes = {
		title: PropTypes.string
	}
}
```
Should parse correctly with this fix.
