### PR TITLE
chore: 🤖 Bump eslint parser and plugin to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
 		"eslint": "^7"
 	},
 	"dependencies": {
-		"@typescript-eslint/eslint-plugin": "^4.2.0",
-		"@typescript-eslint/parser": "^4.2.0",
+		"@typescript-eslint/eslint-plugin": "^5.12.0",
+		"@typescript-eslint/parser": "^5.12.0",
 		"babel-eslint": "^10.0.3",
 		"eslint-config-prettier": "^6.5.0",
 		"eslint-config-standard": "^14.1.0",


### PR DESCRIPTION
This update is needed so that Tradeshift scripts can be updated. The
Tradeshift scripts update will then allow repos to successfully update
to major version 8 of eslint.

BREAKING CHANGE: 🧨 eslint parser and plugin v4 to v5

✅ Closes: FP-1420