### PR TITLE
Fix JSX syntax after parser changes

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,11 @@
 module.exports = {
-	parser: '@babel/eslint-parser',
 	extends: ['standard', 'prettier'],
 	parserOptions: {
-		requireConfigFile: false
+		requireConfigFile: false,
+		ecmaVersion: 'latest',
+		ecmaFeatures: {
+			jsx: true,
+		},
 	},
 	rules: {
 		'standard/computed-property-even-spacing': 'off',

--- a/package.json
+++ b/package.json
@@ -72,5 +72,23 @@
 		"tradeshift",
 		"es6",
 		"es2016"
-	]
+	],
+	"prettier": {
+		"printWidth": 80,
+		"tabWidth": 2,
+		"useTabs": true,
+		"semi": true,
+		"singleQuote": true,
+		"quoteProps": "as-needed",
+		"jsxSingleQuote": false,
+		"trailingComma": "all",
+		"bracketSpacing": true,
+		"arrowParens": "always",
+		"requirePragma": false,
+		"insertPragma": false,
+		"proseWrap": "preserve",
+		"htmlWhitespaceSensitivity": "css",
+		"vueIndentScriptAndStyle": false,
+		"endOfLine": "lf"
+	}
 }

--- a/test/validate-config.js
+++ b/test/validate-config.js
@@ -1,16 +1,16 @@
 const { ESLint } = require('eslint');
 const test = require('tape');
 
-test('load config in eslint to validate all rule syntax is correct', async function(t) {
+test('load config in eslint to validate all rule syntax is correct', async function (t) {
 	const eslint = new ESLint({
 		useEslintrc: false,
 		baseConfig: {
 			extends: [
 				require.resolve('../'),
 				require.resolve('../jest'),
-				require.resolve('../typescript')
-			]
-		}
+				require.resolve('../typescript'),
+			],
+		},
 	});
 
 	const code = `
@@ -29,5 +29,32 @@ test('load config in eslint to validate all rule syntax is correct', async funct
 
 	t.deepEqual(resultsJS[0].messages, []);
 	t.deepEqual(resultsTS[0].messages, []);
+	t.end();
+});
+
+test('check for JSX support', async function (t) {
+	const eslint = new ESLint({
+		useEslintrc: false,
+		baseConfig: {
+			extends: [require.resolve('../'), require.resolve('../typescript')],
+		},
+	});
+
+	const code = `
+export const AwesomeJSX = () => (
+	<section className="jsx-section">
+		woop
+	</section>
+);
+`;
+
+	const resultsJS = await eslint.lintText(code, { filePath: 'index.js' });
+	t.deepEqual(resultsJS[0].messages, [], 'Should parse JSX in *.js');
+	const resultsJSX = await eslint.lintText(code, { filePath: 'index.jsx' });
+	t.deepEqual(resultsJSX[0].messages, [], 'Should parse JSX in *.jsx');
+	// Note: typescript conventions dont allow JSX in *.ts files
+	const resultsTSX = await eslint.lintText(code, { filePath: 'index.tsx' });
+	t.deepEqual(resultsTSX[0].messages, [], 'Should parse JSX in *.tsx');
+
 	t.end();
 });


### PR DESCRIPTION
With eslint 8 we don't need babel anymore! Actually that only makes things more complicated.
Let's remove it, so we can avoid configuring babel.

- fix: parser fix for JSX syntax + test
