### PR TITLE
chore: update dependency tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,24 +61,24 @@
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.17.8",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.8.tgz",
-			"integrity": "sha512-OdQDV/7cRBtJHLSOBqqbYNkOcydOgnX59TZx4puf41fzcVtN3e/4yqY8lMQsK+5X2lJtAdmA+6OHqsj1hBJ4IQ==",
+			"version": "7.17.9",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.9.tgz",
+			"integrity": "sha512-5ug+SfZCpDAkVp9SFIZAzlW18rlzsOcJGaetCjkySnrXXDUw9AR8cDUm1iByTmdWM6yxX6/zycaV76w3YTF2gw==",
 			"dependencies": {
 				"@ampproject/remapping": "^2.1.0",
 				"@babel/code-frame": "^7.16.7",
-				"@babel/generator": "^7.17.7",
+				"@babel/generator": "^7.17.9",
 				"@babel/helper-compilation-targets": "^7.17.7",
 				"@babel/helper-module-transforms": "^7.17.7",
-				"@babel/helpers": "^7.17.8",
-				"@babel/parser": "^7.17.8",
+				"@babel/helpers": "^7.17.9",
+				"@babel/parser": "^7.17.9",
 				"@babel/template": "^7.16.7",
-				"@babel/traverse": "^7.17.3",
+				"@babel/traverse": "^7.17.9",
 				"@babel/types": "^7.17.0",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
-				"json5": "^2.1.2",
+				"json5": "^2.2.1",
 				"semver": "^6.3.0"
 			},
 			"engines": {
@@ -107,9 +107,9 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.17.7",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.7.tgz",
-			"integrity": "sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==",
+			"version": "7.17.9",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.9.tgz",
+			"integrity": "sha512-rAdDousTwxbIxbz5I7GEQ3lUip+xVCXooZNbsydCWs3xA7ZsYOv+CFRdzGxRX78BmQHu9B1Eso59AOZQOJDEdQ==",
 			"dependencies": {
 				"@babel/types": "^7.17.0",
 				"jsesc": "^2.5.1",
@@ -148,24 +148,12 @@
 			}
 		},
 		"node_modules/@babel/helper-function-name": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.7.tgz",
-			"integrity": "sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==",
+			"version": "7.17.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.17.9.tgz",
+			"integrity": "sha512-7cRisGlVtiVqZ0MW0/yFB4atgpGLWEHUVYnb448hZK4x+vih0YO5UoS11XIYtZYqHd0dIPMdUSv8q5K4LdMnIg==",
 			"dependencies": {
-				"@babel/helper-get-function-arity": "^7.16.7",
 				"@babel/template": "^7.16.7",
-				"@babel/types": "^7.16.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-get-function-arity": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz",
-			"integrity": "sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==",
-			"dependencies": {
-				"@babel/types": "^7.16.7"
+				"@babel/types": "^7.17.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -250,12 +238,12 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.17.8",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.8.tgz",
-			"integrity": "sha512-QcL86FGxpfSJwGtAvv4iG93UL6bmqBdmoVY0CMCU2g+oD2ezQse3PT5Pa+jiD6LJndBQi0EDlpzOWNlLuhz5gw==",
+			"version": "7.17.9",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.9.tgz",
+			"integrity": "sha512-cPCt915ShDWUEzEp3+UNRktO2n6v49l5RSnG9M5pS24hA+2FAc5si+Pn1i4VVbQQ+jh+bIZhPFQOJOzbrOYY1Q==",
 			"dependencies": {
 				"@babel/template": "^7.16.7",
-				"@babel/traverse": "^7.17.3",
+				"@babel/traverse": "^7.17.9",
 				"@babel/types": "^7.17.0"
 			},
 			"engines": {
@@ -263,9 +251,9 @@
 			}
 		},
 		"node_modules/@babel/highlight": {
-			"version": "7.16.10",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
-			"integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
+			"version": "7.17.9",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.9.tgz",
+			"integrity": "sha512-J9PfEKCbFIv2X5bjTMiZu6Vf341N05QIY+d6FvVKynkG1S7G0j3I0QoRtWIrXhZ+/Nlb5Q0MzqL7TokEJ5BNHg==",
 			"dependencies": {
 				"@babel/helper-validator-identifier": "^7.16.7",
 				"chalk": "^2.0.0",
@@ -276,9 +264,9 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.17.8",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.8.tgz",
-			"integrity": "sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==",
+			"version": "7.17.9",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.9.tgz",
+			"integrity": "sha512-vqUSBLP8dQHFPdPi9bc5GK9vRkYHJ49fsZdtoJ8EQ8ibpwk5rPKfvNIwChB0KVXcIjcepEBBd2VHC5r9Gy8ueg==",
 			"bin": {
 				"parser": "bin/babel-parser.js"
 			},
@@ -300,17 +288,17 @@
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.17.3",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.3.tgz",
-			"integrity": "sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==",
+			"version": "7.17.9",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.9.tgz",
+			"integrity": "sha512-PQO8sDIJ8SIwipTPiR71kJQCKQYB5NGImbOviK8K+kg5xkNSYXLBupuX9QhatFowrsvo9Hj8WgArg3W7ijNAQw==",
 			"dependencies": {
 				"@babel/code-frame": "^7.16.7",
-				"@babel/generator": "^7.17.3",
+				"@babel/generator": "^7.17.9",
 				"@babel/helper-environment-visitor": "^7.16.7",
-				"@babel/helper-function-name": "^7.16.7",
+				"@babel/helper-function-name": "^7.17.9",
 				"@babel/helper-hoist-variables": "^7.16.7",
 				"@babel/helper-split-export-declaration": "^7.16.7",
-				"@babel/parser": "^7.17.3",
+				"@babel/parser": "^7.17.9",
 				"@babel/types": "^7.17.0",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0"
@@ -672,19 +660,28 @@
 				"semantic-release": ">=19.0.0"
 			}
 		},
+		"node_modules/@semantic-release/npm/node_modules/lru-cache": {
+			"version": "7.7.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.3.tgz",
+			"integrity": "sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/@semantic-release/npm/node_modules/semver": {
-			"version": "7.3.5",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+			"version": "7.3.6",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
+			"integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
 			"dev": true,
 			"dependencies": {
-				"lru-cache": "^6.0.0"
+				"lru-cache": "^7.4.0"
 			},
 			"bin": {
 				"semver": "bin/semver.js"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": "^10.0.0 || ^12.0.0 || ^14.0.0 || >=16.0.0"
 			}
 		},
 		"node_modules/@semantic-release/release-notes-generator": {
@@ -786,18 +783,26 @@
 				}
 			}
 		},
+		"node_modules/@typescript-eslint/eslint-plugin/node_modules/lru-cache": {
+			"version": "7.7.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.3.tgz",
+			"integrity": "sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw==",
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-			"version": "7.3.5",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+			"version": "7.3.6",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
+			"integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
 			"dependencies": {
-				"lru-cache": "^6.0.0"
+				"lru-cache": "^7.4.0"
 			},
 			"bin": {
 				"semver": "bin/semver.js"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": "^10.0.0 || ^12.0.0 || ^14.0.0 || >=16.0.0"
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
@@ -905,18 +910,26 @@
 				}
 			}
 		},
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/lru-cache": {
+			"version": "7.7.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.3.tgz",
+			"integrity": "sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw==",
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-			"version": "7.3.5",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+			"version": "7.3.6",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
+			"integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
 			"dependencies": {
-				"lru-cache": "^6.0.0"
+				"lru-cache": "^7.4.0"
 			},
 			"bin": {
 				"semver": "bin/semver.js"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": "^10.0.0 || ^12.0.0 || ^14.0.0 || >=16.0.0"
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
@@ -1727,9 +1740,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.103",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.103.tgz",
-			"integrity": "sha512-c/uKWR1Z/W30Wy/sx3dkZoj4BijbXX85QKWu9jJfjho3LBAXNEGAEW3oWiGb+dotA6C6BzCTxL2/aLes7jlUeg=="
+			"version": "1.4.106",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.106.tgz",
+			"integrity": "sha512-ZYfpVLULm67K7CaaGP7DmjyeMY4naxsbTy+syVVxT6QHI1Ww8XbJjmr9fDckrhq44WzCrcC5kH3zGpdusxwwqg=="
 		},
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
@@ -2015,23 +2028,23 @@
 			}
 		},
 		"node_modules/eslint-plugin-import": {
-			"version": "2.25.4",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.25.4.tgz",
-			"integrity": "sha512-/KJBASVFxpu0xg1kIBn9AUa8hQVnszpwgE7Ld0lKAlx7Ie87yzEzCgSkekt+le/YVhiaosO4Y14GDAOc41nfxA==",
+			"version": "2.26.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz",
+			"integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
 			"dependencies": {
 				"array-includes": "^3.1.4",
 				"array.prototype.flat": "^1.2.5",
 				"debug": "^2.6.9",
 				"doctrine": "^2.1.0",
 				"eslint-import-resolver-node": "^0.3.6",
-				"eslint-module-utils": "^2.7.2",
+				"eslint-module-utils": "^2.7.3",
 				"has": "^1.0.3",
-				"is-core-module": "^2.8.0",
+				"is-core-module": "^2.8.1",
 				"is-glob": "^4.0.3",
-				"minimatch": "^3.0.4",
+				"minimatch": "^3.1.2",
 				"object.values": "^1.1.5",
-				"resolve": "^1.20.0",
-				"tsconfig-paths": "^3.12.0"
+				"resolve": "^1.22.0",
+				"tsconfig-paths": "^3.14.1"
 			},
 			"engines": {
 				"node": ">=4"
@@ -3619,6 +3632,7 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
 			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dev": true,
 			"dependencies": {
 				"yallist": "^4.0.0"
 			},
@@ -3885,19 +3899,28 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/normalize-package-data/node_modules/lru-cache": {
+			"version": "7.7.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.3.tgz",
+			"integrity": "sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/normalize-package-data/node_modules/semver": {
-			"version": "7.3.5",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+			"version": "7.3.6",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
+			"integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
 			"dev": true,
 			"dependencies": {
-				"lru-cache": "^6.0.0"
+				"lru-cache": "^7.4.0"
 			},
 			"bin": {
 				"semver": "bin/semver.js"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": "^10.0.0 || ^12.0.0 || ^14.0.0 || >=16.0.0"
 			}
 		},
 		"node_modules/normalize-url": {
@@ -7059,6 +7082,15 @@
 				"node": ">=16 || ^14.17"
 			}
 		},
+		"node_modules/semantic-release/node_modules/lru-cache": {
+			"version": "7.7.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.3.tgz",
+			"integrity": "sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/semantic-release/node_modules/resolve-from": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -7069,18 +7101,18 @@
 			}
 		},
 		"node_modules/semantic-release/node_modules/semver": {
-			"version": "7.3.5",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+			"version": "7.3.6",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
+			"integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
 			"dev": true,
 			"dependencies": {
-				"lru-cache": "^6.0.0"
+				"lru-cache": "^7.4.0"
 			},
 			"bin": {
 				"semver": "bin/semver.js"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": "^10.0.0 || ^12.0.0 || ^14.0.0 || >=16.0.0"
 			}
 		},
 		"node_modules/semver": {
@@ -7952,7 +7984,8 @@
 		"node_modules/yallist": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"dev": true
 		},
 		"node_modules/yaml": {
 			"version": "1.10.2",
@@ -8014,24 +8047,24 @@
 			"integrity": "sha512-p8pdE6j0a29TNGebNm7NzYZWB3xVZJBZ7XGs42uAKzQo8VQ3F0By/cQCtUEABwIqw5zo6WA4NbmxsfzADzMKnQ=="
 		},
 		"@babel/core": {
-			"version": "7.17.8",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.8.tgz",
-			"integrity": "sha512-OdQDV/7cRBtJHLSOBqqbYNkOcydOgnX59TZx4puf41fzcVtN3e/4yqY8lMQsK+5X2lJtAdmA+6OHqsj1hBJ4IQ==",
+			"version": "7.17.9",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.9.tgz",
+			"integrity": "sha512-5ug+SfZCpDAkVp9SFIZAzlW18rlzsOcJGaetCjkySnrXXDUw9AR8cDUm1iByTmdWM6yxX6/zycaV76w3YTF2gw==",
 			"requires": {
 				"@ampproject/remapping": "^2.1.0",
 				"@babel/code-frame": "^7.16.7",
-				"@babel/generator": "^7.17.7",
+				"@babel/generator": "^7.17.9",
 				"@babel/helper-compilation-targets": "^7.17.7",
 				"@babel/helper-module-transforms": "^7.17.7",
-				"@babel/helpers": "^7.17.8",
-				"@babel/parser": "^7.17.8",
+				"@babel/helpers": "^7.17.9",
+				"@babel/parser": "^7.17.9",
 				"@babel/template": "^7.16.7",
-				"@babel/traverse": "^7.17.3",
+				"@babel/traverse": "^7.17.9",
 				"@babel/types": "^7.17.0",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
-				"json5": "^2.1.2",
+				"json5": "^2.2.1",
 				"semver": "^6.3.0"
 			}
 		},
@@ -8046,9 +8079,9 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.17.7",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.7.tgz",
-			"integrity": "sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==",
+			"version": "7.17.9",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.9.tgz",
+			"integrity": "sha512-rAdDousTwxbIxbz5I7GEQ3lUip+xVCXooZNbsydCWs3xA7ZsYOv+CFRdzGxRX78BmQHu9B1Eso59AOZQOJDEdQ==",
 			"requires": {
 				"@babel/types": "^7.17.0",
 				"jsesc": "^2.5.1",
@@ -8075,21 +8108,12 @@
 			}
 		},
 		"@babel/helper-function-name": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.7.tgz",
-			"integrity": "sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==",
+			"version": "7.17.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.17.9.tgz",
+			"integrity": "sha512-7cRisGlVtiVqZ0MW0/yFB4atgpGLWEHUVYnb448hZK4x+vih0YO5UoS11XIYtZYqHd0dIPMdUSv8q5K4LdMnIg==",
 			"requires": {
-				"@babel/helper-get-function-arity": "^7.16.7",
 				"@babel/template": "^7.16.7",
-				"@babel/types": "^7.16.7"
-			}
-		},
-		"@babel/helper-get-function-arity": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz",
-			"integrity": "sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==",
-			"requires": {
-				"@babel/types": "^7.16.7"
+				"@babel/types": "^7.17.0"
 			}
 		},
 		"@babel/helper-hoist-variables": {
@@ -8150,19 +8174,19 @@
 			"integrity": "sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ=="
 		},
 		"@babel/helpers": {
-			"version": "7.17.8",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.8.tgz",
-			"integrity": "sha512-QcL86FGxpfSJwGtAvv4iG93UL6bmqBdmoVY0CMCU2g+oD2ezQse3PT5Pa+jiD6LJndBQi0EDlpzOWNlLuhz5gw==",
+			"version": "7.17.9",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.9.tgz",
+			"integrity": "sha512-cPCt915ShDWUEzEp3+UNRktO2n6v49l5RSnG9M5pS24hA+2FAc5si+Pn1i4VVbQQ+jh+bIZhPFQOJOzbrOYY1Q==",
 			"requires": {
 				"@babel/template": "^7.16.7",
-				"@babel/traverse": "^7.17.3",
+				"@babel/traverse": "^7.17.9",
 				"@babel/types": "^7.17.0"
 			}
 		},
 		"@babel/highlight": {
-			"version": "7.16.10",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
-			"integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
+			"version": "7.17.9",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.9.tgz",
+			"integrity": "sha512-J9PfEKCbFIv2X5bjTMiZu6Vf341N05QIY+d6FvVKynkG1S7G0j3I0QoRtWIrXhZ+/Nlb5Q0MzqL7TokEJ5BNHg==",
 			"requires": {
 				"@babel/helper-validator-identifier": "^7.16.7",
 				"chalk": "^2.0.0",
@@ -8170,9 +8194,9 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.17.8",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.8.tgz",
-			"integrity": "sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ=="
+			"version": "7.17.9",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.9.tgz",
+			"integrity": "sha512-vqUSBLP8dQHFPdPi9bc5GK9vRkYHJ49fsZdtoJ8EQ8ibpwk5rPKfvNIwChB0KVXcIjcepEBBd2VHC5r9Gy8ueg=="
 		},
 		"@babel/template": {
 			"version": "7.16.7",
@@ -8185,17 +8209,17 @@
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.17.3",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.3.tgz",
-			"integrity": "sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==",
+			"version": "7.17.9",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.9.tgz",
+			"integrity": "sha512-PQO8sDIJ8SIwipTPiR71kJQCKQYB5NGImbOviK8K+kg5xkNSYXLBupuX9QhatFowrsvo9Hj8WgArg3W7ijNAQw==",
 			"requires": {
 				"@babel/code-frame": "^7.16.7",
-				"@babel/generator": "^7.17.3",
+				"@babel/generator": "^7.17.9",
 				"@babel/helper-environment-visitor": "^7.16.7",
-				"@babel/helper-function-name": "^7.16.7",
+				"@babel/helper-function-name": "^7.17.9",
 				"@babel/helper-hoist-variables": "^7.16.7",
 				"@babel/helper-split-export-declaration": "^7.16.7",
-				"@babel/parser": "^7.17.3",
+				"@babel/parser": "^7.17.9",
 				"@babel/types": "^7.17.0",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0"
@@ -8496,13 +8520,19 @@
 				"tempy": "^1.0.0"
 			},
 			"dependencies": {
+				"lru-cache": {
+					"version": "7.7.3",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.3.tgz",
+					"integrity": "sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw==",
+					"dev": true
+				},
 				"semver": {
-					"version": "7.3.5",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+					"version": "7.3.6",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
+					"integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
 					"dev": true,
 					"requires": {
-						"lru-cache": "^6.0.0"
+						"lru-cache": "^7.4.0"
 					}
 				}
 			}
@@ -8581,12 +8611,17 @@
 				"tsutils": "^3.21.0"
 			},
 			"dependencies": {
+				"lru-cache": {
+					"version": "7.7.3",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.3.tgz",
+					"integrity": "sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw=="
+				},
 				"semver": {
-					"version": "7.3.5",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+					"version": "7.3.6",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
+					"integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
 					"requires": {
-						"lru-cache": "^6.0.0"
+						"lru-cache": "^7.4.0"
 					}
 				}
 			}
@@ -8640,12 +8675,17 @@
 				"tsutils": "^3.21.0"
 			},
 			"dependencies": {
+				"lru-cache": {
+					"version": "7.7.3",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.3.tgz",
+					"integrity": "sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw=="
+				},
 				"semver": {
-					"version": "7.3.5",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+					"version": "7.3.6",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
+					"integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
 					"requires": {
-						"lru-cache": "^6.0.0"
+						"lru-cache": "^7.4.0"
 					}
 				}
 			}
@@ -9245,9 +9285,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.4.103",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.103.tgz",
-			"integrity": "sha512-c/uKWR1Z/W30Wy/sx3dkZoj4BijbXX85QKWu9jJfjho3LBAXNEGAEW3oWiGb+dotA6C6BzCTxL2/aLes7jlUeg=="
+			"version": "1.4.106",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.106.tgz",
+			"integrity": "sha512-ZYfpVLULm67K7CaaGP7DmjyeMY4naxsbTy+syVVxT6QHI1Ww8XbJjmr9fDckrhq44WzCrcC5kH3zGpdusxwwqg=="
 		},
 		"emoji-regex": {
 			"version": "8.0.0",
@@ -9545,23 +9585,23 @@
 			}
 		},
 		"eslint-plugin-import": {
-			"version": "2.25.4",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.25.4.tgz",
-			"integrity": "sha512-/KJBASVFxpu0xg1kIBn9AUa8hQVnszpwgE7Ld0lKAlx7Ie87yzEzCgSkekt+le/YVhiaosO4Y14GDAOc41nfxA==",
+			"version": "2.26.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz",
+			"integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
 			"requires": {
 				"array-includes": "^3.1.4",
 				"array.prototype.flat": "^1.2.5",
 				"debug": "^2.6.9",
 				"doctrine": "^2.1.0",
 				"eslint-import-resolver-node": "^0.3.6",
-				"eslint-module-utils": "^2.7.2",
+				"eslint-module-utils": "^2.7.3",
 				"has": "^1.0.3",
-				"is-core-module": "^2.8.0",
+				"is-core-module": "^2.8.1",
 				"is-glob": "^4.0.3",
-				"minimatch": "^3.0.4",
+				"minimatch": "^3.1.2",
 				"object.values": "^1.1.5",
-				"resolve": "^1.20.0",
-				"tsconfig-paths": "^3.12.0"
+				"resolve": "^1.22.0",
+				"tsconfig-paths": "^3.14.1"
 			},
 			"dependencies": {
 				"debug": {
@@ -10608,6 +10648,7 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
 			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dev": true,
 			"requires": {
 				"yallist": "^4.0.0"
 			}
@@ -10798,13 +10839,19 @@
 				"validate-npm-package-license": "^3.0.1"
 			},
 			"dependencies": {
+				"lru-cache": {
+					"version": "7.7.3",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.3.tgz",
+					"integrity": "sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw==",
+					"dev": true
+				},
 				"semver": {
-					"version": "7.3.5",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+					"version": "7.3.6",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
+					"integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
 					"dev": true,
 					"requires": {
-						"lru-cache": "^6.0.0"
+						"lru-cache": "^7.4.0"
 					}
 				}
 			}
@@ -13027,6 +13074,12 @@
 				"yargs": "^16.2.0"
 			},
 			"dependencies": {
+				"lru-cache": {
+					"version": "7.7.3",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.3.tgz",
+					"integrity": "sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw==",
+					"dev": true
+				},
 				"resolve-from": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -13034,12 +13087,12 @@
 					"dev": true
 				},
 				"semver": {
-					"version": "7.3.5",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+					"version": "7.3.6",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
+					"integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
 					"dev": true,
 					"requires": {
-						"lru-cache": "^6.0.0"
+						"lru-cache": "^7.4.0"
 					}
 				}
 			}
@@ -13721,7 +13774,8 @@
 		"yallist": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"dev": true
 		},
 		"yaml": {
 			"version": "1.10.2",


### PR DESCRIPTION
Updated dependency tree for the lock file of your node project. 

By regenerating the lockfiles, the dependency tree has been updated to pull in the latest packages that match the dependency ranges in `package.json`. For each of those dependencies, the sub-dependencies are updated and so on. 

None of these updates should be a breaking change, since they respect the [version ranges](https://semver.npmjs.com/). They'll potentially save you and your team a lot of time by preventing `Dependabot` vulnerability alerts that you'd have to deal with manually otherwise. 

Good luck!

_This workflow was created and is maintained by the [Developer Productivity](https://tradeshift.slack.com/archives/C78TDU0FJ) team._