### PR TITLE
chore: update dependency tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -661,9 +661,9 @@
 			}
 		},
 		"node_modules/@semantic-release/npm/node_modules/lru-cache": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.3.tgz",
-			"integrity": "sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw==",
+			"version": "7.8.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.8.1.tgz",
+			"integrity": "sha512-E1v547OCgJvbvevfjgK9sNKIVXO96NnsTsFPBlg4ZxjhsJSODoH9lk8Bm0OxvHNm6Vm5Yqkl/1fErDxhYL8Skg==",
 			"dev": true,
 			"engines": {
 				"node": ">=12"
@@ -784,9 +784,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin/node_modules/lru-cache": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.3.tgz",
-			"integrity": "sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw==",
+			"version": "7.8.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.8.1.tgz",
+			"integrity": "sha512-E1v547OCgJvbvevfjgK9sNKIVXO96NnsTsFPBlg4ZxjhsJSODoH9lk8Bm0OxvHNm6Vm5Yqkl/1fErDxhYL8Skg==",
 			"engines": {
 				"node": ">=12"
 			}
@@ -911,9 +911,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/lru-cache": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.3.tgz",
-			"integrity": "sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw==",
+			"version": "7.8.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.8.1.tgz",
+			"integrity": "sha512-E1v547OCgJvbvevfjgK9sNKIVXO96NnsTsFPBlg4ZxjhsJSODoH9lk8Bm0OxvHNm6Vm5Yqkl/1fErDxhYL8Skg==",
 			"engines": {
 				"node": ">=12"
 			}
@@ -1288,9 +1288,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001325",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001325.tgz",
-			"integrity": "sha512-sB1bZHjseSjDtijV1Hb7PB2Zd58Kyx+n/9EotvZ4Qcz2K3d0lWB8dB4nb8wN/TsOGFq3UuAm0zQZNQ4SoR7TrQ==",
+			"version": "1.0.30001327",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001327.tgz",
+			"integrity": "sha512-1/Cg4jlD9qjZzhbzkzEaAC2JHsP0WrOc8Rd/3a3LuajGzGWR/hD7TVyvq99VqmTy99eVh8Zkmdq213OgvgXx7w==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -1864,9 +1864,9 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "8.12.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.12.0.tgz",
-			"integrity": "sha512-it1oBL9alZg1S8UycLm5YDMAkIhtH6FtAzuZs6YvoGVldWjbS08BkAdb/ymP9LlAyq8koANu32U7Ib/w+UNh8Q==",
+			"version": "8.13.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.13.0.tgz",
+			"integrity": "sha512-D+Xei61eInqauAyTJ6C0q6x9mx7kTUC1KZ0m0LSEexR0V+e94K12LmWX076ZIsldwfQ2RONdaJe0re0TRGQbRQ==",
 			"dependencies": {
 				"@eslint/eslintrc": "^1.2.1",
 				"@humanwhocodes/config-array": "^0.9.2",
@@ -2078,9 +2078,9 @@
 			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 		},
 		"node_modules/eslint-plugin-jest": {
-			"version": "26.1.3",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-26.1.3.tgz",
-			"integrity": "sha512-Pju+T7MFpo5VFhFlwrkK/9jRUu18r2iugvgyrWOnnGRaVTFFmFXp+xFJpHyqmjjLmGJPKLeEFLVTAxezkApcpQ==",
+			"version": "26.1.4",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-26.1.4.tgz",
+			"integrity": "sha512-wgqxujmqc2qpvZqMFWCh6Cniqc8lWpapvXt9j/19DmBDqeDaYhJrSRezYR1SKyemvjx+9e9kny/dgRahraHImA==",
 			"dependencies": {
 				"@typescript-eslint/utils": "^5.10.0"
 			},
@@ -3653,9 +3653,9 @@
 			}
 		},
 		"node_modules/marked": {
-			"version": "4.0.12",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
-			"integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+			"version": "4.0.14",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-4.0.14.tgz",
+			"integrity": "sha512-HL5sSPE/LP6U9qKgngIIPTthuxC0jrfxpYMZ3LdGDD3vTnLs59m2Z7r6+LNDR3ToqEQdkKd6YaaEfJhodJmijQ==",
 			"dev": true,
 			"bin": {
 				"marked": "bin/marked.js"
@@ -3900,9 +3900,9 @@
 			}
 		},
 		"node_modules/normalize-package-data/node_modules/lru-cache": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.3.tgz",
-			"integrity": "sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw==",
+			"version": "7.8.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.8.1.tgz",
+			"integrity": "sha512-E1v547OCgJvbvevfjgK9sNKIVXO96NnsTsFPBlg4ZxjhsJSODoH9lk8Bm0OxvHNm6Vm5Yqkl/1fErDxhYL8Skg==",
 			"dev": true,
 			"engines": {
 				"node": ">=12"
@@ -7083,9 +7083,9 @@
 			}
 		},
 		"node_modules/semantic-release/node_modules/lru-cache": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.3.tgz",
-			"integrity": "sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw==",
+			"version": "7.8.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.8.1.tgz",
+			"integrity": "sha512-E1v547OCgJvbvevfjgK9sNKIVXO96NnsTsFPBlg4ZxjhsJSODoH9lk8Bm0OxvHNm6Vm5Yqkl/1fErDxhYL8Skg==",
 			"dev": true,
 			"engines": {
 				"node": ">=12"
@@ -7482,9 +7482,9 @@
 			}
 		},
 		"node_modules/tape": {
-			"version": "5.5.2",
-			"resolved": "https://registry.npmjs.org/tape/-/tape-5.5.2.tgz",
-			"integrity": "sha512-N9Ss672dFE3QlppiXGh2ieux8Ophau/HSAQguW5cXQworKxV0QvnZCYI35W1OYySTJk0OC9OPuS+0xNO6lhiTQ==",
+			"version": "5.5.3",
+			"resolved": "https://registry.npmjs.org/tape/-/tape-5.5.3.tgz",
+			"integrity": "sha512-hPBJZBL9S7bH9vECg/KSM24slGYV589jJr4dmtiJrLD71AL66+8o4b9HdZazXZyvnilqA7eE8z5/flKiy0KsBg==",
 			"dev": true,
 			"dependencies": {
 				"array.prototype.every": "^1.1.3",
@@ -7499,7 +7499,7 @@
 				"has-dynamic-import": "^2.0.1",
 				"inherits": "^2.0.4",
 				"is-regex": "^1.1.4",
-				"minimist": "^1.2.5",
+				"minimist": "^1.2.6",
 				"object-inspect": "^1.12.0",
 				"object-is": "^1.1.5",
 				"object-keys": "^1.1.1",
@@ -7726,9 +7726,9 @@
 			}
 		},
 		"node_modules/uglify-js": {
-			"version": "3.15.3",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.3.tgz",
-			"integrity": "sha512-6iCVm2omGJbsu3JWac+p6kUiOpg3wFO2f8lIXjfEb8RrmLjzog1wTPMmwKB7swfzzqxj9YM+sGUM++u1qN4qJg==",
+			"version": "3.15.4",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.4.tgz",
+			"integrity": "sha512-vMOPGDuvXecPs34V74qDKk4iJ/SN4vL3Ow/23ixafENYvtrNvtbcgUeugTcUGRGsOF/5fU8/NYSL5Hyb3l1OJA==",
 			"dev": true,
 			"optional": true,
 			"bin": {
@@ -8521,9 +8521,9 @@
 			},
 			"dependencies": {
 				"lru-cache": {
-					"version": "7.7.3",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.3.tgz",
-					"integrity": "sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw==",
+					"version": "7.8.1",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.8.1.tgz",
+					"integrity": "sha512-E1v547OCgJvbvevfjgK9sNKIVXO96NnsTsFPBlg4ZxjhsJSODoH9lk8Bm0OxvHNm6Vm5Yqkl/1fErDxhYL8Skg==",
 					"dev": true
 				},
 				"semver": {
@@ -8612,9 +8612,9 @@
 			},
 			"dependencies": {
 				"lru-cache": {
-					"version": "7.7.3",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.3.tgz",
-					"integrity": "sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw=="
+					"version": "7.8.1",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.8.1.tgz",
+					"integrity": "sha512-E1v547OCgJvbvevfjgK9sNKIVXO96NnsTsFPBlg4ZxjhsJSODoH9lk8Bm0OxvHNm6Vm5Yqkl/1fErDxhYL8Skg=="
 				},
 				"semver": {
 					"version": "7.3.6",
@@ -8676,9 +8676,9 @@
 			},
 			"dependencies": {
 				"lru-cache": {
-					"version": "7.7.3",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.3.tgz",
-					"integrity": "sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw=="
+					"version": "7.8.1",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.8.1.tgz",
+					"integrity": "sha512-E1v547OCgJvbvevfjgK9sNKIVXO96NnsTsFPBlg4ZxjhsJSODoH9lk8Bm0OxvHNm6Vm5Yqkl/1fErDxhYL8Skg=="
 				},
 				"semver": {
 					"version": "7.3.6",
@@ -8934,9 +8934,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001325",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001325.tgz",
-			"integrity": "sha512-sB1bZHjseSjDtijV1Hb7PB2Zd58Kyx+n/9EotvZ4Qcz2K3d0lWB8dB4nb8wN/TsOGFq3UuAm0zQZNQ4SoR7TrQ=="
+			"version": "1.0.30001327",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001327.tgz",
+			"integrity": "sha512-1/Cg4jlD9qjZzhbzkzEaAC2JHsP0WrOc8Rd/3a3LuajGzGWR/hD7TVyvq99VqmTy99eVh8Zkmdq213OgvgXx7w=="
 		},
 		"cardinal": {
 			"version": "2.1.1",
@@ -9387,9 +9387,9 @@
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"eslint": {
-			"version": "8.12.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.12.0.tgz",
-			"integrity": "sha512-it1oBL9alZg1S8UycLm5YDMAkIhtH6FtAzuZs6YvoGVldWjbS08BkAdb/ymP9LlAyq8koANu32U7Ib/w+UNh8Q==",
+			"version": "8.13.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.13.0.tgz",
+			"integrity": "sha512-D+Xei61eInqauAyTJ6C0q6x9mx7kTUC1KZ0m0LSEexR0V+e94K12LmWX076ZIsldwfQ2RONdaJe0re0TRGQbRQ==",
 			"requires": {
 				"@eslint/eslintrc": "^1.2.1",
 				"@humanwhocodes/config-array": "^0.9.2",
@@ -9628,9 +9628,9 @@
 			}
 		},
 		"eslint-plugin-jest": {
-			"version": "26.1.3",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-26.1.3.tgz",
-			"integrity": "sha512-Pju+T7MFpo5VFhFlwrkK/9jRUu18r2iugvgyrWOnnGRaVTFFmFXp+xFJpHyqmjjLmGJPKLeEFLVTAxezkApcpQ==",
+			"version": "26.1.4",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-26.1.4.tgz",
+			"integrity": "sha512-wgqxujmqc2qpvZqMFWCh6Cniqc8lWpapvXt9j/19DmBDqeDaYhJrSRezYR1SKyemvjx+9e9kny/dgRahraHImA==",
 			"requires": {
 				"@typescript-eslint/utils": "^5.10.0"
 			}
@@ -10660,9 +10660,9 @@
 			"dev": true
 		},
 		"marked": {
-			"version": "4.0.12",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
-			"integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+			"version": "4.0.14",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-4.0.14.tgz",
+			"integrity": "sha512-HL5sSPE/LP6U9qKgngIIPTthuxC0jrfxpYMZ3LdGDD3vTnLs59m2Z7r6+LNDR3ToqEQdkKd6YaaEfJhodJmijQ==",
 			"dev": true
 		},
 		"marked-terminal": {
@@ -10840,9 +10840,9 @@
 			},
 			"dependencies": {
 				"lru-cache": {
-					"version": "7.7.3",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.3.tgz",
-					"integrity": "sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw==",
+					"version": "7.8.1",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.8.1.tgz",
+					"integrity": "sha512-E1v547OCgJvbvevfjgK9sNKIVXO96NnsTsFPBlg4ZxjhsJSODoH9lk8Bm0OxvHNm6Vm5Yqkl/1fErDxhYL8Skg==",
 					"dev": true
 				},
 				"semver": {
@@ -13075,9 +13075,9 @@
 			},
 			"dependencies": {
 				"lru-cache": {
-					"version": "7.7.3",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.3.tgz",
-					"integrity": "sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw==",
+					"version": "7.8.1",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.8.1.tgz",
+					"integrity": "sha512-E1v547OCgJvbvevfjgK9sNKIVXO96NnsTsFPBlg4ZxjhsJSODoH9lk8Bm0OxvHNm6Vm5Yqkl/1fErDxhYL8Skg==",
 					"dev": true
 				},
 				"resolve-from": {
@@ -13380,9 +13380,9 @@
 			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
 		},
 		"tape": {
-			"version": "5.5.2",
-			"resolved": "https://registry.npmjs.org/tape/-/tape-5.5.2.tgz",
-			"integrity": "sha512-N9Ss672dFE3QlppiXGh2ieux8Ophau/HSAQguW5cXQworKxV0QvnZCYI35W1OYySTJk0OC9OPuS+0xNO6lhiTQ==",
+			"version": "5.5.3",
+			"resolved": "https://registry.npmjs.org/tape/-/tape-5.5.3.tgz",
+			"integrity": "sha512-hPBJZBL9S7bH9vECg/KSM24slGYV589jJr4dmtiJrLD71AL66+8o4b9HdZazXZyvnilqA7eE8z5/flKiy0KsBg==",
 			"dev": true,
 			"requires": {
 				"array.prototype.every": "^1.1.3",
@@ -13397,7 +13397,7 @@
 				"has-dynamic-import": "^2.0.1",
 				"inherits": "^2.0.4",
 				"is-regex": "^1.1.4",
-				"minimist": "^1.2.5",
+				"minimist": "^1.2.6",
 				"object-inspect": "^1.12.0",
 				"object-is": "^1.1.5",
 				"object-keys": "^1.1.1",
@@ -13571,9 +13571,9 @@
 			"integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw=="
 		},
 		"uglify-js": {
-			"version": "3.15.3",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.3.tgz",
-			"integrity": "sha512-6iCVm2omGJbsu3JWac+p6kUiOpg3wFO2f8lIXjfEb8RrmLjzog1wTPMmwKB7swfzzqxj9YM+sGUM++u1qN4qJg==",
+			"version": "3.15.4",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.4.tgz",
+			"integrity": "sha512-vMOPGDuvXecPs34V74qDKk4iJ/SN4vL3Ow/23ixafENYvtrNvtbcgUeugTcUGRGsOF/5fU8/NYSL5Hyb3l1OJA==",
 			"dev": true,
 			"optional": true
 		},


### PR DESCRIPTION
Updated dependency tree for the lock file of your node project. 

By regenerating the lockfiles, the dependency tree has been updated to pull in the latest packages that match the dependency ranges in `package.json`. For each of those dependencies, the sub-dependencies are updated and so on. 

None of these updates should be a breaking change, since they respect the [version ranges](https://semver.npmjs.com/). They'll potentially save you and your team a lot of time by preventing `Dependabot` vulnerability alerts that you'd have to deal with manually otherwise. 

Good luck!

_This workflow was created and is maintained by the [Developer Productivity](https://tradeshift.slack.com/archives/C78TDU0FJ) team._