### PR TITLE
chore: update dependency tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -350,9 +350,9 @@
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.1.tgz",
-			"integrity": "sha512-OhSY22oQQdw3zgPOOwdoj01l/Dzl1Z+xyUP33tkSN+aqyEhymJCcPHyXt+ylW8FSe0TfRC2VG+ROQOapD0aZSQ==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.2.tgz",
+			"integrity": "sha512-AXYd23w1S/bv3fTs3Lz0vjiYemS08jWkI3hYyS9I1ry+0f+Yjs1wm+sU0BS8qDOPrBIkp4qHYC16I8uVtpLajQ==",
 			"dependencies": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
@@ -568,18 +568,18 @@
 			}
 		},
 		"node_modules/@octokit/openapi-types": {
-			"version": "13.9.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.9.0.tgz",
-			"integrity": "sha512-MOYjRyLIM0zzNb9RfEwVK6HLIc2nIF2OMVtMqiNOGbX0SHrQvQbI6X1K16ktmaHr8WUBv+eeul8cD9mz4rNiWQ==",
+			"version": "13.9.1",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.9.1.tgz",
+			"integrity": "sha512-98zOxAAR8MDHjXI2xGKgn/qkZLwfcNjHka0baniuEpN1fCv3kDJeh5qc0mBwim5y31eaPaYer9QikzwOkQq3wQ==",
 			"dev": true
 		},
 		"node_modules/@octokit/plugin-paginate-rest": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-4.2.2.tgz",
-			"integrity": "sha512-oslJFmdcWeB3Q8dzn2WNFBzEAvqCH+cvrjBUhS7uwQxAt5yH91w1eo2flWiR0Rqxh+EijQS5ImoB0iQ3hz7P2Q==",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-4.2.3.tgz",
+			"integrity": "sha512-1RXJZ7hnxSANMtxKSVIEByjhYqqlu2GaKmLJJE/OVDya1aI++hdmXP4ORCUlsN2rt4hJzRYbWizBHlGYKz3dhQ==",
 			"dev": true,
 			"dependencies": {
-				"@octokit/types": "^7.3.0"
+				"@octokit/types": "^7.3.1"
 			},
 			"engines": {
 				"node": ">= 14"
@@ -598,12 +598,12 @@
 			}
 		},
 		"node_modules/@octokit/plugin-rest-endpoint-methods": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-6.5.0.tgz",
-			"integrity": "sha512-+r/tWwc7hI3vYDb+d0hAqbr04Kle6pL+MmGxMDTUn7wIwry5qFXnUA8RCa5CO8EcuHbZLywnqIVRLdM08qV8Ew==",
+			"version": "6.5.2",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-6.5.2.tgz",
+			"integrity": "sha512-zUscUePMC3KEKyTAfuG/dA6hw4Yn7CncVJs2kM9xc4931Iqk3ZiwHfVwTUnxkqQJIVgeBRYUk3rM4hMfgASUxg==",
 			"dev": true,
 			"dependencies": {
-				"@octokit/types": "^7.3.0",
+				"@octokit/types": "^7.3.1",
 				"deprecation": "^2.3.1"
 			},
 			"engines": {
@@ -660,12 +660,12 @@
 			}
 		},
 		"node_modules/@octokit/types": {
-			"version": "7.3.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-7.3.0.tgz",
-			"integrity": "sha512-7Ar22AVxsJBYZuPkGQwFQybGt2YjuP6j6Z36bPntIYy3R9qSowB55mXOsb16hc0UqtJkYBrRMVXKlaX1OHsh1g==",
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-7.3.1.tgz",
+			"integrity": "sha512-Vefohn8pHGFYWbSc6du0wXMK/Pmy6h0H4lttBw5WqquEuxjdXwyYX07CeZpJDkzSzpdKxBoWRNuDJGTE+FvtqA==",
 			"dev": true,
 			"dependencies": {
-				"@octokit/openapi-types": "^13.9.0"
+				"@octokit/openapi-types": "^13.9.1"
 			}
 		},
 		"node_modules/@semantic-release/commit-analyzer": {
@@ -1381,9 +1381,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001393",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001393.tgz",
-			"integrity": "sha512-N/od11RX+Gsk+1qY/jbPa0R6zJupEa0lxeBG598EbrtblxVCTJsQwbRBm6+V+rxpc5lHKdsXb9RY83cZIPLseA==",
+			"version": "1.0.30001397",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001397.tgz",
+			"integrity": "sha512-SW9N2TbCdLf0eiNDRrrQXx2sOkaakNZbCjgNpPyMJJbiOrU5QzMIrXOVMRM1myBXTD5iTkdrtU/EguCrBocHlA==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -1827,9 +1827,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.246",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.246.tgz",
-			"integrity": "sha512-/wFCHUE+Hocqr/LlVGsuKLIw4P2lBWwFIDcNMDpJGzyIysQV4aycpoOitAs32FT94EHKnNqDR/CVZJFbXEufJA=="
+			"version": "1.4.247",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.247.tgz",
+			"integrity": "sha512-FLs6R4FQE+1JHM0hh3sfdxnYjKvJpHZyhQDjc2qFq/xFvmmRt/TATNToZhrcGUFzpF2XjeiuozrA8lI0PZmYYw=="
 		},
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
@@ -1962,11 +1962,11 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "8.23.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.23.0.tgz",
-			"integrity": "sha512-pBG/XOn0MsJcKcTRLr27S5HpzQo4kLr+HjLQIyK4EiCsijDl/TB+h5uEuJU6bQ8Edvwz1XWOjpaP2qgnXGpTcA==",
+			"version": "8.23.1",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.23.1.tgz",
+			"integrity": "sha512-w7C1IXCc6fNqjpuYd0yPlcTKKmHlHHktRkzmBPZ+7cvNBQuiNjx0xaMTjAJGCafJhQkrFJooREv0CtrVzmHwqg==",
 			"dependencies": {
-				"@eslint/eslintrc": "^1.3.1",
+				"@eslint/eslintrc": "^1.3.2",
 				"@humanwhocodes/config-array": "^0.10.4",
 				"@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
 				"@humanwhocodes/module-importer": "^1.0.1",
@@ -1985,7 +1985,6 @@
 				"fast-deep-equal": "^3.1.3",
 				"file-entry-cache": "^6.0.1",
 				"find-up": "^5.0.0",
-				"functional-red-black-tree": "^1.0.1",
 				"glob-parent": "^6.0.1",
 				"globals": "^13.15.0",
 				"globby": "^11.1.0",
@@ -1994,6 +1993,7 @@
 				"import-fresh": "^3.0.0",
 				"imurmurhash": "^0.1.4",
 				"is-glob": "^4.0.0",
+				"js-sdsl": "^4.1.4",
 				"js-yaml": "^4.1.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"levn": "^0.4.1",
@@ -2184,9 +2184,9 @@
 			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
 		},
 		"node_modules/eslint-plugin-jest": {
-			"version": "27.0.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.0.2.tgz",
-			"integrity": "sha512-VEZaj19IMxqg/URcHNT4PhfoJJ1EsFurgq0SjMEYprDCq+et9fKkE4jIHnAsFh3mHLPBgAq04YQqkeW3slXs+Q==",
+			"version": "27.0.4",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.0.4.tgz",
+			"integrity": "sha512-BuvY78pHMpMJ6Cio7sKg6jrqEcnRYPUc4Nlihku4vKx3FjlmMINSX4vcYokZIe+8TKcyr1aI5Kq7vYwgJNdQSA==",
 			"dependencies": {
 				"@typescript-eslint/utils": "^5.10.0"
 			},
@@ -3240,9 +3240,9 @@
 			}
 		},
 		"node_modules/is-callable": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
-			"integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.5.tgz",
+			"integrity": "sha512-ZIWRujF6MvYGkEuHMYtFRkL2wAtFw89EHfKlXrkPkjQZZRWeh9L1q3SV13NIfHnqxugjLvAOkEHx9mb1zcMnEw==",
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -3564,6 +3564,11 @@
 			"engines": {
 				"node": ">= 0.6.0"
 			}
+		},
+		"node_modules/js-sdsl": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.4.tgz",
+			"integrity": "sha512-Y2/yD55y5jteOAmY50JbUZYwk3CP3wnLPEZnlR1w9oKhITrBEtAxwuWKebFf8hMrPMgbYwFoWK/lH2sBkErELw=="
 		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
@@ -8672,9 +8677,9 @@
 			"optional": true
 		},
 		"@eslint/eslintrc": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.1.tgz",
-			"integrity": "sha512-OhSY22oQQdw3zgPOOwdoj01l/Dzl1Z+xyUP33tkSN+aqyEhymJCcPHyXt+ylW8FSe0TfRC2VG+ROQOapD0aZSQ==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.2.tgz",
+			"integrity": "sha512-AXYd23w1S/bv3fTs3Lz0vjiYemS08jWkI3hYyS9I1ry+0f+Yjs1wm+sU0BS8qDOPrBIkp4qHYC16I8uVtpLajQ==",
 			"requires": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
@@ -8830,18 +8835,18 @@
 			}
 		},
 		"@octokit/openapi-types": {
-			"version": "13.9.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.9.0.tgz",
-			"integrity": "sha512-MOYjRyLIM0zzNb9RfEwVK6HLIc2nIF2OMVtMqiNOGbX0SHrQvQbI6X1K16ktmaHr8WUBv+eeul8cD9mz4rNiWQ==",
+			"version": "13.9.1",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.9.1.tgz",
+			"integrity": "sha512-98zOxAAR8MDHjXI2xGKgn/qkZLwfcNjHka0baniuEpN1fCv3kDJeh5qc0mBwim5y31eaPaYer9QikzwOkQq3wQ==",
 			"dev": true
 		},
 		"@octokit/plugin-paginate-rest": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-4.2.2.tgz",
-			"integrity": "sha512-oslJFmdcWeB3Q8dzn2WNFBzEAvqCH+cvrjBUhS7uwQxAt5yH91w1eo2flWiR0Rqxh+EijQS5ImoB0iQ3hz7P2Q==",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-4.2.3.tgz",
+			"integrity": "sha512-1RXJZ7hnxSANMtxKSVIEByjhYqqlu2GaKmLJJE/OVDya1aI++hdmXP4ORCUlsN2rt4hJzRYbWizBHlGYKz3dhQ==",
 			"dev": true,
 			"requires": {
-				"@octokit/types": "^7.3.0"
+				"@octokit/types": "^7.3.1"
 			}
 		},
 		"@octokit/plugin-request-log": {
@@ -8852,12 +8857,12 @@
 			"requires": {}
 		},
 		"@octokit/plugin-rest-endpoint-methods": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-6.5.0.tgz",
-			"integrity": "sha512-+r/tWwc7hI3vYDb+d0hAqbr04Kle6pL+MmGxMDTUn7wIwry5qFXnUA8RCa5CO8EcuHbZLywnqIVRLdM08qV8Ew==",
+			"version": "6.5.2",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-6.5.2.tgz",
+			"integrity": "sha512-zUscUePMC3KEKyTAfuG/dA6hw4Yn7CncVJs2kM9xc4931Iqk3ZiwHfVwTUnxkqQJIVgeBRYUk3rM4hMfgASUxg==",
 			"dev": true,
 			"requires": {
-				"@octokit/types": "^7.3.0",
+				"@octokit/types": "^7.3.1",
 				"deprecation": "^2.3.1"
 			}
 		},
@@ -8899,12 +8904,12 @@
 			}
 		},
 		"@octokit/types": {
-			"version": "7.3.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-7.3.0.tgz",
-			"integrity": "sha512-7Ar22AVxsJBYZuPkGQwFQybGt2YjuP6j6Z36bPntIYy3R9qSowB55mXOsb16hc0UqtJkYBrRMVXKlaX1OHsh1g==",
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-7.3.1.tgz",
+			"integrity": "sha512-Vefohn8pHGFYWbSc6du0wXMK/Pmy6h0H4lttBw5WqquEuxjdXwyYX07CeZpJDkzSzpdKxBoWRNuDJGTE+FvtqA==",
 			"dev": true,
 			"requires": {
-				"@octokit/openapi-types": "^13.9.0"
+				"@octokit/openapi-types": "^13.9.1"
 			}
 		},
 		"@semantic-release/commit-analyzer": {
@@ -9390,9 +9395,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001393",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001393.tgz",
-			"integrity": "sha512-N/od11RX+Gsk+1qY/jbPa0R6zJupEa0lxeBG598EbrtblxVCTJsQwbRBm6+V+rxpc5lHKdsXb9RY83cZIPLseA=="
+			"version": "1.0.30001397",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001397.tgz",
+			"integrity": "sha512-SW9N2TbCdLf0eiNDRrrQXx2sOkaakNZbCjgNpPyMJJbiOrU5QzMIrXOVMRM1myBXTD5iTkdrtU/EguCrBocHlA=="
 		},
 		"cardinal": {
 			"version": "2.1.1",
@@ -9735,9 +9740,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.4.246",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.246.tgz",
-			"integrity": "sha512-/wFCHUE+Hocqr/LlVGsuKLIw4P2lBWwFIDcNMDpJGzyIysQV4aycpoOitAs32FT94EHKnNqDR/CVZJFbXEufJA=="
+			"version": "1.4.247",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.247.tgz",
+			"integrity": "sha512-FLs6R4FQE+1JHM0hh3sfdxnYjKvJpHZyhQDjc2qFq/xFvmmRt/TATNToZhrcGUFzpF2XjeiuozrA8lI0PZmYYw=="
 		},
 		"emoji-regex": {
 			"version": "8.0.0",
@@ -9848,11 +9853,11 @@
 			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
 		},
 		"eslint": {
-			"version": "8.23.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.23.0.tgz",
-			"integrity": "sha512-pBG/XOn0MsJcKcTRLr27S5HpzQo4kLr+HjLQIyK4EiCsijDl/TB+h5uEuJU6bQ8Edvwz1XWOjpaP2qgnXGpTcA==",
+			"version": "8.23.1",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.23.1.tgz",
+			"integrity": "sha512-w7C1IXCc6fNqjpuYd0yPlcTKKmHlHHktRkzmBPZ+7cvNBQuiNjx0xaMTjAJGCafJhQkrFJooREv0CtrVzmHwqg==",
 			"requires": {
-				"@eslint/eslintrc": "^1.3.1",
+				"@eslint/eslintrc": "^1.3.2",
 				"@humanwhocodes/config-array": "^0.10.4",
 				"@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
 				"@humanwhocodes/module-importer": "^1.0.1",
@@ -9871,7 +9876,6 @@
 				"fast-deep-equal": "^3.1.3",
 				"file-entry-cache": "^6.0.1",
 				"find-up": "^5.0.0",
-				"functional-red-black-tree": "^1.0.1",
 				"glob-parent": "^6.0.1",
 				"globals": "^13.15.0",
 				"globby": "^11.1.0",
@@ -9880,6 +9884,7 @@
 				"import-fresh": "^3.0.0",
 				"imurmurhash": "^0.1.4",
 				"is-glob": "^4.0.0",
+				"js-sdsl": "^4.1.4",
 				"js-yaml": "^4.1.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"levn": "^0.4.1",
@@ -10092,9 +10097,9 @@
 			}
 		},
 		"eslint-plugin-jest": {
-			"version": "27.0.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.0.2.tgz",
-			"integrity": "sha512-VEZaj19IMxqg/URcHNT4PhfoJJ1EsFurgq0SjMEYprDCq+et9fKkE4jIHnAsFh3mHLPBgAq04YQqkeW3slXs+Q==",
+			"version": "27.0.4",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.0.4.tgz",
+			"integrity": "sha512-BuvY78pHMpMJ6Cio7sKg6jrqEcnRYPUc4Nlihku4vKx3FjlmMINSX4vcYokZIe+8TKcyr1aI5Kq7vYwgJNdQSA==",
 			"requires": {
 				"@typescript-eslint/utils": "^5.10.0"
 			}
@@ -10743,9 +10748,9 @@
 			}
 		},
 		"is-callable": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
-			"integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w=="
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.5.tgz",
+			"integrity": "sha512-ZIWRujF6MvYGkEuHMYtFRkL2wAtFw89EHfKlXrkPkjQZZRWeh9L1q3SV13NIfHnqxugjLvAOkEHx9mb1zcMnEw=="
 		},
 		"is-core-module": {
 			"version": "2.10.0",
@@ -10956,6 +10961,11 @@
 			"resolved": "https://registry.npmjs.org/java-properties/-/java-properties-1.0.2.tgz",
 			"integrity": "sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==",
 			"dev": true
+		},
+		"js-sdsl": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.4.tgz",
+			"integrity": "sha512-Y2/yD55y5jteOAmY50JbUZYwk3CP3wnLPEZnlR1w9oKhITrBEtAxwuWKebFf8hMrPMgbYwFoWK/lH2sBkErELw=="
 		},
 		"js-tokens": {
 			"version": "4.0.0",


### PR DESCRIPTION
Updated dependency tree for the lock file of your node project. 

By regenerating the lockfiles, the dependency tree has been updated to pull in the latest packages that match the dependency ranges in `package.json`. For each of those dependencies, the sub-dependencies are updated and so on. 

None of these updates should be a breaking change, since they respect the [version ranges](https://semver.npmjs.com/). They'll potentially save you and your team a lot of time by preventing `Dependabot` vulnerability alerts that you'd have to deal with manually otherwise. 

Good luck!

_This workflow was created and is maintained by the [Developer Productivity](https://tradeshift.slack.com/archives/C78TDU0FJ) team._