### PR TITLE
chore: update dependency tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -576,18 +576,18 @@
 			}
 		},
 		"node_modules/@octokit/openapi-types": {
-			"version": "13.10.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.10.0.tgz",
-			"integrity": "sha512-wPQDpTyy35D6VS/lekXDaKcxy6LI2hzcbmXBnP180Pdgz3dXRzoHdav0w09yZzzWX8HHLGuqwAeyMqEPtWY2XA==",
+			"version": "13.12.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.12.0.tgz",
+			"integrity": "sha512-1QYzZrwnn3rTQE7ZoSxXrO8lhu0aIbac1c+qIPOPEaVXBWSaUyLV1x9yt4uDQOwmu6u5ywVS8OJgs+ErDLf6vQ==",
 			"dev": true
 		},
 		"node_modules/@octokit/plugin-paginate-rest": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-4.3.0.tgz",
-			"integrity": "sha512-4V8hWMoXuxb03xPs3s3RjUb5Bzx4HmVRhG+gvbO08PB48ag6G8mk6/HDFKlAXz9XEorDIkc0pXcXnaOz8spHgg==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-4.3.1.tgz",
+			"integrity": "sha512-h8KKxESmSFTcXX409CAxlaOYscEDvN2KGQRsLCGT1NSqRW+D6EXLVQ8vuHhFznS9MuH9QYw1GfsUN30bg8hjVA==",
 			"dev": true,
 			"dependencies": {
-				"@octokit/types": "^7.4.0"
+				"@octokit/types": "^7.5.0"
 			},
 			"engines": {
 				"node": ">= 14"
@@ -606,12 +606,12 @@
 			}
 		},
 		"node_modules/@octokit/plugin-rest-endpoint-methods": {
-			"version": "6.6.0",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-6.6.0.tgz",
-			"integrity": "sha512-IAuT/e1gIUVszNmV+vfXNxa6xXI9dlghhBDqLGEmjz3so9sHqOlXN4R5gWcCRJkt4mum4NCaNjUk17yTrK76Rw==",
+			"version": "6.6.2",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-6.6.2.tgz",
+			"integrity": "sha512-n9dL5KMpz9qVFSNdcVWC8ZPbl68QbTk7+CMPXCXqaMZOLn1n1YuoSFFCy84Ge0fx333fUqpnBHv8BFjwGtUQkA==",
 			"dev": true,
 			"dependencies": {
-				"@octokit/types": "^7.4.0",
+				"@octokit/types": "^7.5.0",
 				"deprecation": "^2.3.1"
 			},
 			"engines": {
@@ -668,12 +668,12 @@
 			}
 		},
 		"node_modules/@octokit/types": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-7.4.0.tgz",
-			"integrity": "sha512-ln1GW0p72+P8qeRjHGj0wyR5ePy6slqvczveOqonMk1w1UWua6UgrkwFzv6S0vKWjSqt/ijYXF1ehNVRRRSvLA==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-7.5.0.tgz",
+			"integrity": "sha512-aHm+olfIZjQpzoODpl+RCZzchKOrdSLJs+yfI7pMMcmB19Li6vidgx0DwUDO/Ic4Q3fq/lOjJORVCcLZefcrJw==",
 			"dev": true,
 			"dependencies": {
-				"@octokit/openapi-types": "^13.10.0"
+				"@octokit/openapi-types": "^13.11.0"
 			}
 		},
 		"node_modules/@semantic-release/commit-analyzer": {
@@ -1389,9 +1389,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001400",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001400.tgz",
-			"integrity": "sha512-Mv659Hn65Z4LgZdJ7ge5JTVbE3rqbJaaXgW5LEI9/tOaXclfIZ8DW7D7FCWWWmWiiPS7AC48S8kf3DApSxQdgA==",
+			"version": "1.0.30001406",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001406.tgz",
+			"integrity": "sha512-bWTlaXUy/rq0BBtYShc/jArYfBPjEV95euvZ8JVtO43oQExEN/WquoqpufFjNu4kSpi5cy5kMbNvzztWDfv1Jg==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -1439,9 +1439,9 @@
 			}
 		},
 		"node_modules/cli-table3": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.2.tgz",
-			"integrity": "sha512-QyavHCaIC80cMivimWu4aWHilIpiDpfm3hGmqAmXVL1UsnbLuBSMd21hTX6VY4ZSDSM73ESLeF8TOYId3rBTbw==",
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.3.tgz",
+			"integrity": "sha512-w5Jac5SykAeZJKntOxJCrm63Eg5/4dhMWIcuTbo9rpE+brgaSZo0RuNJZeOyMgsUdhDeojvgyQLmjI+K50ZGyg==",
 			"dev": true,
 			"dependencies": {
 				"string-width": "^4.2.0"
@@ -1835,9 +1835,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.251",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.251.tgz",
-			"integrity": "sha512-k4o4cFrWPv4SoJGGAydd07GmlRVzmeDIJ6MaEChTUjk4Dmomn189tCicSzil2oyvbPoGgg2suwPDNWq4gWRhoQ=="
+			"version": "1.4.254",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.254.tgz",
+			"integrity": "sha512-Sh/7YsHqQYkA6ZHuHMy24e6TE4eX6KZVsZb9E/DvU1nQRIrH4BflO/4k+83tfdYvDl+MObvlqHPRICzEdC9c6Q=="
 		},
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
@@ -8851,18 +8851,18 @@
 			}
 		},
 		"@octokit/openapi-types": {
-			"version": "13.10.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.10.0.tgz",
-			"integrity": "sha512-wPQDpTyy35D6VS/lekXDaKcxy6LI2hzcbmXBnP180Pdgz3dXRzoHdav0w09yZzzWX8HHLGuqwAeyMqEPtWY2XA==",
+			"version": "13.12.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.12.0.tgz",
+			"integrity": "sha512-1QYzZrwnn3rTQE7ZoSxXrO8lhu0aIbac1c+qIPOPEaVXBWSaUyLV1x9yt4uDQOwmu6u5ywVS8OJgs+ErDLf6vQ==",
 			"dev": true
 		},
 		"@octokit/plugin-paginate-rest": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-4.3.0.tgz",
-			"integrity": "sha512-4V8hWMoXuxb03xPs3s3RjUb5Bzx4HmVRhG+gvbO08PB48ag6G8mk6/HDFKlAXz9XEorDIkc0pXcXnaOz8spHgg==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-4.3.1.tgz",
+			"integrity": "sha512-h8KKxESmSFTcXX409CAxlaOYscEDvN2KGQRsLCGT1NSqRW+D6EXLVQ8vuHhFznS9MuH9QYw1GfsUN30bg8hjVA==",
 			"dev": true,
 			"requires": {
-				"@octokit/types": "^7.4.0"
+				"@octokit/types": "^7.5.0"
 			}
 		},
 		"@octokit/plugin-request-log": {
@@ -8873,12 +8873,12 @@
 			"requires": {}
 		},
 		"@octokit/plugin-rest-endpoint-methods": {
-			"version": "6.6.0",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-6.6.0.tgz",
-			"integrity": "sha512-IAuT/e1gIUVszNmV+vfXNxa6xXI9dlghhBDqLGEmjz3so9sHqOlXN4R5gWcCRJkt4mum4NCaNjUk17yTrK76Rw==",
+			"version": "6.6.2",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-6.6.2.tgz",
+			"integrity": "sha512-n9dL5KMpz9qVFSNdcVWC8ZPbl68QbTk7+CMPXCXqaMZOLn1n1YuoSFFCy84Ge0fx333fUqpnBHv8BFjwGtUQkA==",
 			"dev": true,
 			"requires": {
-				"@octokit/types": "^7.4.0",
+				"@octokit/types": "^7.5.0",
 				"deprecation": "^2.3.1"
 			}
 		},
@@ -8920,12 +8920,12 @@
 			}
 		},
 		"@octokit/types": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-7.4.0.tgz",
-			"integrity": "sha512-ln1GW0p72+P8qeRjHGj0wyR5ePy6slqvczveOqonMk1w1UWua6UgrkwFzv6S0vKWjSqt/ijYXF1ehNVRRRSvLA==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-7.5.0.tgz",
+			"integrity": "sha512-aHm+olfIZjQpzoODpl+RCZzchKOrdSLJs+yfI7pMMcmB19Li6vidgx0DwUDO/Ic4Q3fq/lOjJORVCcLZefcrJw==",
 			"dev": true,
 			"requires": {
-				"@octokit/openapi-types": "^13.10.0"
+				"@octokit/openapi-types": "^13.11.0"
 			}
 		},
 		"@semantic-release/commit-analyzer": {
@@ -9411,9 +9411,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001400",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001400.tgz",
-			"integrity": "sha512-Mv659Hn65Z4LgZdJ7ge5JTVbE3rqbJaaXgW5LEI9/tOaXclfIZ8DW7D7FCWWWmWiiPS7AC48S8kf3DApSxQdgA=="
+			"version": "1.0.30001406",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001406.tgz",
+			"integrity": "sha512-bWTlaXUy/rq0BBtYShc/jArYfBPjEV95euvZ8JVtO43oQExEN/WquoqpufFjNu4kSpi5cy5kMbNvzztWDfv1Jg=="
 		},
 		"cardinal": {
 			"version": "2.1.1",
@@ -9442,9 +9442,9 @@
 			"dev": true
 		},
 		"cli-table3": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.2.tgz",
-			"integrity": "sha512-QyavHCaIC80cMivimWu4aWHilIpiDpfm3hGmqAmXVL1UsnbLuBSMd21hTX6VY4ZSDSM73ESLeF8TOYId3rBTbw==",
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.3.tgz",
+			"integrity": "sha512-w5Jac5SykAeZJKntOxJCrm63Eg5/4dhMWIcuTbo9rpE+brgaSZo0RuNJZeOyMgsUdhDeojvgyQLmjI+K50ZGyg==",
 			"dev": true,
 			"requires": {
 				"@colors/colors": "1.5.0",
@@ -9756,9 +9756,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.4.251",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.251.tgz",
-			"integrity": "sha512-k4o4cFrWPv4SoJGGAydd07GmlRVzmeDIJ6MaEChTUjk4Dmomn189tCicSzil2oyvbPoGgg2suwPDNWq4gWRhoQ=="
+			"version": "1.4.254",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.254.tgz",
+			"integrity": "sha512-Sh/7YsHqQYkA6ZHuHMy24e6TE4eX6KZVsZb9E/DvU1nQRIrH4BflO/4k+83tfdYvDl+MObvlqHPRICzEdC9c6Q=="
 		},
 		"emoji-regex": {
 			"version": "8.0.0",


### PR DESCRIPTION
Updated dependency tree for the lock file of your node project. 

By regenerating the lockfiles, the dependency tree has been updated to pull in the latest packages that match the dependency ranges in `package.json`. For each of those dependencies, the sub-dependencies are updated and so on. 

None of these updates should be a breaking change, since they respect the [version ranges](https://semver.npmjs.com/). They'll potentially save you and your team a lot of time by preventing `Dependabot` vulnerability alerts that you'd have to deal with manually otherwise. 

Good luck!

_This workflow was created and is maintained by the [Developer Productivity](https://tradeshift.slack.com/archives/C78TDU0FJ) team._