### PR TITLE
chore: update dependency tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1388,9 +1388,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001409",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001409.tgz",
-			"integrity": "sha512-V0mnJ5dwarmhYv8/MzhJ//aW68UpvnQBXv8lJ2QUsvn2pHcmAuNtu8hQEDz37XnA1iE+lRR9CIfGWWpgJ5QedQ==",
+			"version": "1.0.30001412",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001412.tgz",
+			"integrity": "sha512-+TeEIee1gS5bYOiuf+PS/kp2mrXic37Hl66VY6EAfxasIk5fELTktK2oOezYed12H8w7jt3s512PpulQidPjwA==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -1834,9 +1834,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.257",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.257.tgz",
-			"integrity": "sha512-C65sIwHqNnPC2ADMfse/jWTtmhZMII+x6ADI9gENzrOiI7BpxmfKFE84WkIEl5wEg+7+SfIkwChDlsd1Erju2A=="
+			"version": "1.4.262",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.262.tgz",
+			"integrity": "sha512-Ckn5haqmGh/xS8IbcgK3dnwAVnhDyo/WQnklWn6yaMucYTq7NNxwlGE8ElzEOnonzRLzUCo2Ot3vUb2GYUF2Hw=="
 		},
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
@@ -1868,21 +1868,21 @@
 			}
 		},
 		"node_modules/es-abstract": {
-			"version": "1.20.2",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.2.tgz",
-			"integrity": "sha512-XxXQuVNrySBNlEkTYJoDNFe5+s2yIOpzq80sUHEdPdQr0S5nTLz4ZPPPswNIpKseDDUS5yghX1gfLIHQZ1iNuQ==",
+			"version": "1.20.3",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.3.tgz",
+			"integrity": "sha512-AyrnaKVpMzljIdwjzrj+LxGmj8ik2LckwXacHqrJJ/jxz6dDDBcZ7I7nlHM0FvEW8MfbWJwOd+yT2XzYW49Frw==",
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"es-to-primitive": "^1.2.1",
 				"function-bind": "^1.1.1",
 				"function.prototype.name": "^1.1.5",
-				"get-intrinsic": "^1.1.2",
+				"get-intrinsic": "^1.1.3",
 				"get-symbol-description": "^1.0.0",
 				"has": "^1.0.3",
 				"has-property-descriptors": "^1.0.0",
 				"has-symbols": "^1.0.3",
 				"internal-slot": "^1.0.3",
-				"is-callable": "^1.2.4",
+				"is-callable": "^1.2.6",
 				"is-negative-zero": "^2.0.2",
 				"is-regex": "^1.1.4",
 				"is-shared-array-buffer": "^1.0.2",
@@ -1892,6 +1892,7 @@
 				"object-keys": "^1.1.1",
 				"object.assign": "^4.1.4",
 				"regexp.prototype.flags": "^1.4.3",
+				"safe-regex-test": "^1.0.0",
 				"string.prototype.trimend": "^1.0.5",
 				"string.prototype.trimstart": "^1.0.5",
 				"unbox-primitive": "^1.0.2"
@@ -1969,12 +1970,12 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "8.23.1",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.23.1.tgz",
-			"integrity": "sha512-w7C1IXCc6fNqjpuYd0yPlcTKKmHlHHktRkzmBPZ+7cvNBQuiNjx0xaMTjAJGCafJhQkrFJooREv0CtrVzmHwqg==",
+			"version": "8.24.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.24.0.tgz",
+			"integrity": "sha512-dWFaPhGhTAiPcCgm3f6LI2MBWbogMnTJzFBbhXVRQDJPkr9pGZvVjlVfXd+vyDcWPA2Ic9L2AXPIQM0+vk/cSQ==",
 			"dependencies": {
 				"@eslint/eslintrc": "^1.3.2",
-				"@humanwhocodes/config-array": "^0.10.4",
+				"@humanwhocodes/config-array": "^0.10.5",
 				"@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"ajv": "^6.10.0",
@@ -3242,9 +3243,9 @@
 			}
 		},
 		"node_modules/is-callable": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.6.tgz",
-			"integrity": "sha512-krO72EO2NptOGAX2KYyqbP9vYMlNAXdB53rq6f8LXY6RY7JdSR/3BD6wLUlPHSAesmY9vstNrjvqGaCiRK/91Q==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -7433,6 +7434,19 @@
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
+		"node_modules/safe-regex-test": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
+			"integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"get-intrinsic": "^1.1.3",
+				"is-regex": "^1.1.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/semantic-release": {
 			"version": "19.0.5",
 			"resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-19.0.5.tgz",
@@ -8120,9 +8134,9 @@
 			}
 		},
 		"node_modules/uglify-js": {
-			"version": "3.17.1",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.1.tgz",
-			"integrity": "sha512-+juFBsLLw7AqMaqJ0GFvlsGZwdQfI2ooKQB39PSBgMnMakcFosi9O8jCwE+2/2nMNcc0z63r9mwjoDG8zr+q0Q==",
+			"version": "3.17.2",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.2.tgz",
+			"integrity": "sha512-bbxglRjsGQMchfvXZNusUcYgiB9Hx2K4AHYXQy2DITZ9Rd+JzhX7+hoocE5Winr7z2oHvPsekkBwXtigvxevXg==",
 			"dev": true,
 			"optional": true,
 			"bin": {
@@ -9407,9 +9421,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001409",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001409.tgz",
-			"integrity": "sha512-V0mnJ5dwarmhYv8/MzhJ//aW68UpvnQBXv8lJ2QUsvn2pHcmAuNtu8hQEDz37XnA1iE+lRR9CIfGWWpgJ5QedQ=="
+			"version": "1.0.30001412",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001412.tgz",
+			"integrity": "sha512-+TeEIee1gS5bYOiuf+PS/kp2mrXic37Hl66VY6EAfxasIk5fELTktK2oOezYed12H8w7jt3s512PpulQidPjwA=="
 		},
 		"cardinal": {
 			"version": "2.1.1",
@@ -9752,9 +9766,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.4.257",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.257.tgz",
-			"integrity": "sha512-C65sIwHqNnPC2ADMfse/jWTtmhZMII+x6ADI9gENzrOiI7BpxmfKFE84WkIEl5wEg+7+SfIkwChDlsd1Erju2A=="
+			"version": "1.4.262",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.262.tgz",
+			"integrity": "sha512-Ckn5haqmGh/xS8IbcgK3dnwAVnhDyo/WQnklWn6yaMucYTq7NNxwlGE8ElzEOnonzRLzUCo2Ot3vUb2GYUF2Hw=="
 		},
 		"emoji-regex": {
 			"version": "8.0.0",
@@ -9783,21 +9797,21 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.20.2",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.2.tgz",
-			"integrity": "sha512-XxXQuVNrySBNlEkTYJoDNFe5+s2yIOpzq80sUHEdPdQr0S5nTLz4ZPPPswNIpKseDDUS5yghX1gfLIHQZ1iNuQ==",
+			"version": "1.20.3",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.3.tgz",
+			"integrity": "sha512-AyrnaKVpMzljIdwjzrj+LxGmj8ik2LckwXacHqrJJ/jxz6dDDBcZ7I7nlHM0FvEW8MfbWJwOd+yT2XzYW49Frw==",
 			"requires": {
 				"call-bind": "^1.0.2",
 				"es-to-primitive": "^1.2.1",
 				"function-bind": "^1.1.1",
 				"function.prototype.name": "^1.1.5",
-				"get-intrinsic": "^1.1.2",
+				"get-intrinsic": "^1.1.3",
 				"get-symbol-description": "^1.0.0",
 				"has": "^1.0.3",
 				"has-property-descriptors": "^1.0.0",
 				"has-symbols": "^1.0.3",
 				"internal-slot": "^1.0.3",
-				"is-callable": "^1.2.4",
+				"is-callable": "^1.2.6",
 				"is-negative-zero": "^2.0.2",
 				"is-regex": "^1.1.4",
 				"is-shared-array-buffer": "^1.0.2",
@@ -9807,6 +9821,7 @@
 				"object-keys": "^1.1.1",
 				"object.assign": "^4.1.4",
 				"regexp.prototype.flags": "^1.4.3",
+				"safe-regex-test": "^1.0.0",
 				"string.prototype.trimend": "^1.0.5",
 				"string.prototype.trimstart": "^1.0.5",
 				"unbox-primitive": "^1.0.2"
@@ -9865,12 +9880,12 @@
 			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
 		},
 		"eslint": {
-			"version": "8.23.1",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.23.1.tgz",
-			"integrity": "sha512-w7C1IXCc6fNqjpuYd0yPlcTKKmHlHHktRkzmBPZ+7cvNBQuiNjx0xaMTjAJGCafJhQkrFJooREv0CtrVzmHwqg==",
+			"version": "8.24.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.24.0.tgz",
+			"integrity": "sha512-dWFaPhGhTAiPcCgm3f6LI2MBWbogMnTJzFBbhXVRQDJPkr9pGZvVjlVfXd+vyDcWPA2Ic9L2AXPIQM0+vk/cSQ==",
 			"requires": {
 				"@eslint/eslintrc": "^1.3.2",
-				"@humanwhocodes/config-array": "^0.10.4",
+				"@humanwhocodes/config-array": "^0.10.5",
 				"@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"ajv": "^6.10.0",
@@ -10755,9 +10770,9 @@
 			}
 		},
 		"is-callable": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.6.tgz",
-			"integrity": "sha512-krO72EO2NptOGAX2KYyqbP9vYMlNAXdB53rq6f8LXY6RY7JdSR/3BD6wLUlPHSAesmY9vstNrjvqGaCiRK/91Q=="
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
 		},
 		"is-core-module": {
 			"version": "2.10.0",
@@ -13691,6 +13706,16 @@
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
+		"safe-regex-test": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
+			"integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+			"requires": {
+				"call-bind": "^1.0.2",
+				"get-intrinsic": "^1.1.3",
+				"is-regex": "^1.1.4"
+			}
+		},
 		"semantic-release": {
 			"version": "19.0.5",
 			"resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-19.0.5.tgz",
@@ -14222,9 +14247,9 @@
 			"integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig=="
 		},
 		"uglify-js": {
-			"version": "3.17.1",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.1.tgz",
-			"integrity": "sha512-+juFBsLLw7AqMaqJ0GFvlsGZwdQfI2ooKQB39PSBgMnMakcFosi9O8jCwE+2/2nMNcc0z63r9mwjoDG8zr+q0Q==",
+			"version": "3.17.2",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.2.tgz",
+			"integrity": "sha512-bbxglRjsGQMchfvXZNusUcYgiB9Hx2K4AHYXQy2DITZ9Rd+JzhX7+hoocE5Winr7z2oHvPsekkBwXtigvxevXg==",
 			"dev": true,
 			"optional": true
 		},


### PR DESCRIPTION
Updated dependency tree for the lock file of your node project. 

By regenerating the lockfiles, the dependency tree has been updated to pull in the latest packages that match the dependency ranges in `package.json`. For each of those dependencies, the sub-dependencies are updated and so on. 

None of these updates should be a breaking change, since they respect the [version ranges](https://semver.npmjs.com/). They'll potentially save you and your team a lot of time by preventing `Dependabot` vulnerability alerts that you'd have to deal with manually otherwise. 

Good luck!

_This workflow was created and is maintained by the [Developer Productivity](https://tradeshift.slack.com/archives/C78TDU0FJ) team._