### PR TITLE
chore: change of ownership from developer-productivity to sre

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,4 +4,4 @@
 # The last matching pattern takes precedence.
 # https://help.github.com/articles/about-codeowners/
 
-*    @Tradeshift/developer-productivity @Tradeshift/ci-workers
+*    @Tradeshift/sre @Tradeshift/ci-workers

--- a/Repofile
+++ b/Repofile
@@ -1,6 +1,6 @@
 {
     "maintainers": [
-        "developer-productivity"
+        "sre"
     ],
     "checks": [
         "npm test (14)"

--- a/catalog-info.yml
+++ b/catalog-info.yml
@@ -11,4 +11,4 @@ metadata:
 spec:
   type: library
   lifecycle: production
-  owner: developer-productivity
+  owner: sre


### PR DESCRIPTION
This PR changes the ownership of this repo to SRE, as the developer productivity team doesn't exist anymore.