### PR TITLE
Dependency Updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node: [14, 16]
+        node: [16, 18]
     steps:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v3
@@ -48,7 +48,7 @@ jobs:
       - name: ⎔ Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 18
           # cache requires lockfile
           # cache: "npm"
 

--- a/Repofile
+++ b/Repofile
@@ -3,6 +3,7 @@
         "sre"
     ],
     "checks": [
-        "npm test (14)"
+        "npm test (16)",
+				"npm test (18)"
     ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,21 +11,23 @@
 			"dependencies": {
 				"@babel/core": "^7.17.7",
 				"@babel/eslint-parser": "^7.17.0",
-				"@typescript-eslint/eslint-plugin": "^5.14.0",
-				"@typescript-eslint/parser": "^5.14.0",
 				"eslint-config-prettier": "^8.5.0",
 				"eslint-config-standard": "^17.0.0-0 || ^17",
 				"eslint-plugin-import": "^2.25.4",
-				"eslint-plugin-jest": "^27.0.2",
-				"eslint-plugin-n": "^15.0.0",
+				"eslint-plugin-jest": "^27.2.3",
+				"eslint-plugin-n": "^16.0.0",
 				"eslint-plugin-promise": "^6.0.0"
 			},
 			"devDependencies": {
+				"@typescript-eslint/eslint-plugin": "6.2.0",
+				"@typescript-eslint/parser": "6.2.0",
 				"eslint": "8.45.0",
 				"tape": "5.6.6",
 				"typescript": "5.1.6"
 			},
 			"peerDependencies": {
+				"@typescript-eslint/eslint-plugin": "^5.0.0 || ^6.0.0",
+				"@typescript-eslint/parser": "^5.0.0 || ^6.0.0",
 				"eslint": "^7 || ^8"
 			}
 		},
@@ -361,9 +363,9 @@
 			}
 		},
 		"node_modules/@eslint-community/regexpp": {
-			"version": "4.5.1",
-			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.1.tgz",
-			"integrity": "sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==",
+			"version": "4.6.1",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.6.1.tgz",
+			"integrity": "sha512-O7x6dMstWLn2ktjcoiNLDkAGG2EjveHL+Vvc+n0fXumkJYAcSqcVYKtwDU+hDZ0uDUsnUagSYaZrOLAYE8un1A==",
 			"engines": {
 				"node": "^12.0.0 || ^14.0.0 || >=16.0.0"
 			}
@@ -567,31 +569,34 @@
 			"integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw=="
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "5.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.60.0.tgz",
-			"integrity": "sha512-78B+anHLF1TI8Jn/cD0Q00TBYdMgjdOn980JfAVa9yw5sop8nyTfVOQAv6LWywkOGLclDBtv5z3oxN4w7jxyNg==",
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.2.0.tgz",
+			"integrity": "sha512-rClGrMuyS/3j0ETa1Ui7s6GkLhfZGKZL3ZrChLeAiACBE/tRc1wq8SNZESUuluxhLj9FkUefRs2l6bCIArWBiQ==",
+			"devOptional": true,
 			"dependencies": {
-				"@eslint-community/regexpp": "^4.4.0",
-				"@typescript-eslint/scope-manager": "5.60.0",
-				"@typescript-eslint/type-utils": "5.60.0",
-				"@typescript-eslint/utils": "5.60.0",
+				"@eslint-community/regexpp": "^4.5.1",
+				"@typescript-eslint/scope-manager": "6.2.0",
+				"@typescript-eslint/type-utils": "6.2.0",
+				"@typescript-eslint/utils": "6.2.0",
+				"@typescript-eslint/visitor-keys": "6.2.0",
 				"debug": "^4.3.4",
-				"grapheme-splitter": "^1.0.4",
-				"ignore": "^5.2.0",
+				"graphemer": "^1.4.0",
+				"ignore": "^5.2.4",
+				"natural-compare": "^1.4.0",
 				"natural-compare-lite": "^1.4.0",
-				"semver": "^7.3.7",
-				"tsutils": "^3.21.0"
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^5.0.0",
-				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+				"@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
+				"eslint": "^7.0.0 || ^8.0.0"
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
@@ -599,10 +604,122 @@
 				}
 			}
 		},
+		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.2.0.tgz",
+			"integrity": "sha512-1ZMNVgm5nnHURU8ZSJ3snsHzpFeNK84rdZjluEVBGNu7jDymfqceB3kdIZ6A4xCfEFFhRIB6rF8q/JIqJd2R0Q==",
+			"devOptional": true,
+			"dependencies": {
+				"@typescript-eslint/types": "6.2.0",
+				"@typescript-eslint/visitor-keys": "6.2.0"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.2.0.tgz",
+			"integrity": "sha512-1nRRaDlp/XYJQLvkQJG5F3uBTno5SHPT7XVcJ5n1/k2WfNI28nJsvLakxwZRNY5spuatEKO7d5nZWsQpkqXwBA==",
+			"devOptional": true,
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/typescript-estree": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.2.0.tgz",
+			"integrity": "sha512-Mts6+3HQMSM+LZCglsc2yMIny37IhUgp1Qe8yJUYVyO6rHP7/vN0vajKu3JvHCBIy8TSiKddJ/Zwu80jhnGj1w==",
+			"devOptional": true,
+			"dependencies": {
+				"@typescript-eslint/types": "6.2.0",
+				"@typescript-eslint/visitor-keys": "6.2.0",
+				"debug": "^4.3.4",
+				"globby": "^11.1.0",
+				"is-glob": "^4.0.3",
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.2.0.tgz",
+			"integrity": "sha512-RCFrC1lXiX1qEZN8LmLrxYRhOkElEsPKTVSNout8DMzf8PeWoQG7Rxz2SadpJa3VSh5oYKGwt7j7X/VRg+Y3OQ==",
+			"devOptional": true,
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.4.0",
+				"@types/json-schema": "^7.0.12",
+				"@types/semver": "^7.5.0",
+				"@typescript-eslint/scope-manager": "6.2.0",
+				"@typescript-eslint/types": "6.2.0",
+				"@typescript-eslint/typescript-estree": "6.2.0",
+				"semver": "^7.5.4"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.2.0.tgz",
+			"integrity": "sha512-QbaYUQVKKo9bgCzpjz45llCfwakyoxHetIy8CAvYCtd16Zu1KrpzNHofwF8kGkpPOxZB2o6kz+0nqH8ZkIzuoQ==",
+			"devOptional": true,
+			"dependencies": {
+				"@typescript-eslint/types": "6.2.0",
+				"eslint-visitor-keys": "^3.4.1"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/eslint-plugin/node_modules/eslint-visitor-keys": {
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
+			"integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
+			"devOptional": true,
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
 		"node_modules/@typescript-eslint/eslint-plugin/node_modules/lru-cache": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
 			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"devOptional": true,
 			"dependencies": {
 				"yallist": "^4.0.0"
 			},
@@ -611,9 +728,10 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-			"version": "7.5.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-			"integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+			"devOptional": true,
 			"dependencies": {
 				"lru-cache": "^6.0.0"
 			},
@@ -627,33 +745,155 @@
 		"node_modules/@typescript-eslint/eslint-plugin/node_modules/yallist": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"devOptional": true
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "5.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.60.0.tgz",
-			"integrity": "sha512-jBONcBsDJ9UoTWrARkRRCgDz6wUggmH5RpQVlt7BimSwaTkTjwypGzKORXbR4/2Hqjk9hgwlon2rVQAjWNpkyQ==",
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.2.0.tgz",
+			"integrity": "sha512-igVYOqtiK/UsvKAmmloQAruAdUHihsOCvplJpplPZ+3h4aDkC/UKZZNKgB6h93ayuYLuEymU3h8nF1xMRbh37g==",
+			"devOptional": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "5.60.0",
-				"@typescript-eslint/types": "5.60.0",
-				"@typescript-eslint/typescript-estree": "5.60.0",
+				"@typescript-eslint/scope-manager": "6.2.0",
+				"@typescript-eslint/types": "6.2.0",
+				"@typescript-eslint/typescript-estree": "6.2.0",
+				"@typescript-eslint/visitor-keys": "6.2.0",
 				"debug": "^4.3.4"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+				"eslint": "^7.0.0 || ^8.0.0"
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
 					"optional": true
 				}
 			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.2.0.tgz",
+			"integrity": "sha512-1ZMNVgm5nnHURU8ZSJ3snsHzpFeNK84rdZjluEVBGNu7jDymfqceB3kdIZ6A4xCfEFFhRIB6rF8q/JIqJd2R0Q==",
+			"devOptional": true,
+			"dependencies": {
+				"@typescript-eslint/types": "6.2.0",
+				"@typescript-eslint/visitor-keys": "6.2.0"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.2.0.tgz",
+			"integrity": "sha512-1nRRaDlp/XYJQLvkQJG5F3uBTno5SHPT7XVcJ5n1/k2WfNI28nJsvLakxwZRNY5spuatEKO7d5nZWsQpkqXwBA==",
+			"devOptional": true,
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.2.0.tgz",
+			"integrity": "sha512-Mts6+3HQMSM+LZCglsc2yMIny37IhUgp1Qe8yJUYVyO6rHP7/vN0vajKu3JvHCBIy8TSiKddJ/Zwu80jhnGj1w==",
+			"devOptional": true,
+			"dependencies": {
+				"@typescript-eslint/types": "6.2.0",
+				"@typescript-eslint/visitor-keys": "6.2.0",
+				"debug": "^4.3.4",
+				"globby": "^11.1.0",
+				"is-glob": "^4.0.3",
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.2.0.tgz",
+			"integrity": "sha512-QbaYUQVKKo9bgCzpjz45llCfwakyoxHetIy8CAvYCtd16Zu1KrpzNHofwF8kGkpPOxZB2o6kz+0nqH8ZkIzuoQ==",
+			"devOptional": true,
+			"dependencies": {
+				"@typescript-eslint/types": "6.2.0",
+				"eslint-visitor-keys": "^3.4.1"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/eslint-visitor-keys": {
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
+			"integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
+			"devOptional": true,
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"devOptional": true,
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/semver": {
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+			"devOptional": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"devOptional": true
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
 			"version": "5.60.0",
@@ -672,30 +912,175 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "5.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.60.0.tgz",
-			"integrity": "sha512-X7NsRQddORMYRFH7FWo6sA9Y/zbJ8s1x1RIAtnlj6YprbToTiQnM6vxcMu7iYhdunmoC0rUWlca13D5DVHkK2g==",
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.2.0.tgz",
+			"integrity": "sha512-DnGZuNU2JN3AYwddYIqrVkYW0uUQdv0AY+kz2M25euVNlujcN2u+rJgfJsBFlUEzBB6OQkUqSZPyuTLf2bP5mw==",
+			"devOptional": true,
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "5.60.0",
-				"@typescript-eslint/utils": "5.60.0",
+				"@typescript-eslint/typescript-estree": "6.2.0",
+				"@typescript-eslint/utils": "6.2.0",
 				"debug": "^4.3.4",
-				"tsutils": "^3.21.0"
+				"ts-api-utils": "^1.0.1"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "*"
+				"eslint": "^7.0.0 || ^8.0.0"
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
 					"optional": true
 				}
 			}
+		},
+		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/scope-manager": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.2.0.tgz",
+			"integrity": "sha512-1ZMNVgm5nnHURU8ZSJ3snsHzpFeNK84rdZjluEVBGNu7jDymfqceB3kdIZ6A4xCfEFFhRIB6rF8q/JIqJd2R0Q==",
+			"devOptional": true,
+			"dependencies": {
+				"@typescript-eslint/types": "6.2.0",
+				"@typescript-eslint/visitor-keys": "6.2.0"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.2.0.tgz",
+			"integrity": "sha512-1nRRaDlp/XYJQLvkQJG5F3uBTno5SHPT7XVcJ5n1/k2WfNI28nJsvLakxwZRNY5spuatEKO7d5nZWsQpkqXwBA==",
+			"devOptional": true,
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.2.0.tgz",
+			"integrity": "sha512-Mts6+3HQMSM+LZCglsc2yMIny37IhUgp1Qe8yJUYVyO6rHP7/vN0vajKu3JvHCBIy8TSiKddJ/Zwu80jhnGj1w==",
+			"devOptional": true,
+			"dependencies": {
+				"@typescript-eslint/types": "6.2.0",
+				"@typescript-eslint/visitor-keys": "6.2.0",
+				"debug": "^4.3.4",
+				"globby": "^11.1.0",
+				"is-glob": "^4.0.3",
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/utils": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.2.0.tgz",
+			"integrity": "sha512-RCFrC1lXiX1qEZN8LmLrxYRhOkElEsPKTVSNout8DMzf8PeWoQG7Rxz2SadpJa3VSh5oYKGwt7j7X/VRg+Y3OQ==",
+			"devOptional": true,
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.4.0",
+				"@types/json-schema": "^7.0.12",
+				"@types/semver": "^7.5.0",
+				"@typescript-eslint/scope-manager": "6.2.0",
+				"@typescript-eslint/types": "6.2.0",
+				"@typescript-eslint/typescript-estree": "6.2.0",
+				"semver": "^7.5.4"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/visitor-keys": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.2.0.tgz",
+			"integrity": "sha512-QbaYUQVKKo9bgCzpjz45llCfwakyoxHetIy8CAvYCtd16Zu1KrpzNHofwF8kGkpPOxZB2o6kz+0nqH8ZkIzuoQ==",
+			"devOptional": true,
+			"dependencies": {
+				"@typescript-eslint/types": "6.2.0",
+				"eslint-visitor-keys": "^3.4.1"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/type-utils/node_modules/eslint-visitor-keys": {
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
+			"integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
+			"devOptional": true,
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/type-utils/node_modules/lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"devOptional": true,
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@typescript-eslint/type-utils/node_modules/semver": {
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+			"devOptional": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@typescript-eslint/type-utils/node_modules/yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"devOptional": true
 		},
 		"node_modules/@typescript-eslint/types": {
 			"version": "5.60.0",
@@ -1555,44 +1940,22 @@
 				"ms": "^2.1.1"
 			}
 		},
-		"node_modules/eslint-plugin-es": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-4.1.0.tgz",
-			"integrity": "sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==",
+		"node_modules/eslint-plugin-es-x": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.2.0.tgz",
+			"integrity": "sha512-9dvv5CcvNjSJPqnS5uZkqb3xmbeqRLnvXKK7iI5+oK/yTusyc46zbBZKENGsOfojm/mKfszyZb+wNqNPAPeGXA==",
 			"dependencies": {
-				"eslint-utils": "^2.0.0",
-				"regexpp": "^3.0.0"
+				"@eslint-community/eslint-utils": "^4.1.2",
+				"@eslint-community/regexpp": "^4.6.0"
 			},
 			"engines": {
-				"node": ">=8.10.0"
+				"node": "^14.18.0 || >=16.0.0"
 			},
 			"funding": {
-				"url": "https://github.com/sponsors/mysticatea"
+				"url": "https://github.com/sponsors/ota-meshi"
 			},
 			"peerDependencies": {
-				"eslint": ">=4.19.1"
-			}
-		},
-		"node_modules/eslint-plugin-es/node_modules/eslint-utils": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-			"integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
-			"dependencies": {
-				"eslint-visitor-keys": "^1.1.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/mysticatea"
-			}
-		},
-		"node_modules/eslint-plugin-es/node_modules/eslint-visitor-keys": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-			"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-			"engines": {
-				"node": ">=4"
+				"eslint": ">=8"
 			}
 		},
 		"node_modules/eslint-plugin-import": {
@@ -1643,9 +2006,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-jest": {
-			"version": "27.2.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.2.2.tgz",
-			"integrity": "sha512-euzbp06F934Z7UDl5ZUaRPLAc9MKjh0rMPERrHT7UhlCEwgb25kBj37TvMgWeHZVkR5I9CayswrpoaqZU1RImw==",
+			"version": "27.2.3",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.2.3.tgz",
+			"integrity": "sha512-sRLlSCpICzWuje66Gl9zvdF6mwD5X86I4u55hJyFBsxYOsBCmT5+kSUjf+fkFWVMMgpzNEupjW8WzUqi83hJAQ==",
 			"dependencies": {
 				"@typescript-eslint/utils": "^5.10.0"
 			},
@@ -1653,7 +2016,7 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/eslint-plugin": "^5.0.0",
+				"@typescript-eslint/eslint-plugin": "^5.0.0 || ^6.0.0",
 				"eslint": "^7.0.0 || ^8.0.0",
 				"jest": "*"
 			},
@@ -1667,21 +2030,21 @@
 			}
 		},
 		"node_modules/eslint-plugin-n": {
-			"version": "15.7.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.7.0.tgz",
-			"integrity": "sha512-jDex9s7D/Qial8AGVIHq4W7NswpUD5DPDL2RH8Lzd9EloWUuvUkHfv4FRLMipH5q2UtyurorBkPeNi1wVWNh3Q==",
+			"version": "16.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-16.0.1.tgz",
+			"integrity": "sha512-CDmHegJN0OF3L5cz5tATH84RPQm9kG+Yx39wIqIwPR2C0uhBGMWfbbOtetR83PQjjidA5aXMu+LEFw1jaSwvTA==",
 			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.4.0",
 				"builtins": "^5.0.1",
-				"eslint-plugin-es": "^4.1.0",
-				"eslint-utils": "^3.0.0",
-				"ignore": "^5.1.1",
-				"is-core-module": "^2.11.0",
+				"eslint-plugin-es-x": "^7.1.0",
+				"ignore": "^5.2.4",
+				"is-core-module": "^2.12.1",
 				"minimatch": "^3.1.2",
-				"resolve": "^1.22.1",
-				"semver": "^7.3.8"
+				"resolve": "^1.22.2",
+				"semver": "^7.5.3"
 			},
 			"engines": {
-				"node": ">=12.22.0"
+				"node": ">=16.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/mysticatea"
@@ -1741,23 +2104,6 @@
 			},
 			"engines": {
 				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/eslint-utils": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-			"integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-			"dependencies": {
-				"eslint-visitor-keys": "^2.0.0"
-			},
-			"engines": {
-				"node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/mysticatea"
-			},
-			"peerDependencies": {
-				"eslint": ">=5"
 			}
 		},
 		"node_modules/eslint-visitor-keys": {
@@ -2245,11 +2591,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/grapheme-splitter": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-			"integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="
 		},
 		"node_modules/graphemer": {
 			"version": "1.4.0",
@@ -2825,7 +3166,8 @@
 		"node_modules/natural-compare-lite": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
-			"integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g=="
+			"integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
+			"devOptional": true
 		},
 		"node_modules/node-releases": {
 			"version": "2.0.12",
@@ -3062,17 +3404,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/regexpp": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-			"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/mysticatea"
 			}
 		},
 		"node_modules/resolve": {
@@ -3385,6 +3716,18 @@
 			},
 			"engines": {
 				"node": ">=8.0"
+			}
+		},
+		"node_modules/ts-api-utils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.1.tgz",
+			"integrity": "sha512-lC/RGlPmwdrIBFTX59wwNzqh7aR2otPNPR/5brHZm/XKFYKsfqxihXUe9pU3JI+3vGkl+vyCoNNnPhJn3aLK1A==",
+			"devOptional": true,
+			"engines": {
+				"node": ">=16.13.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.2.0"
 			}
 		},
 		"node_modules/tsconfig-paths": {
@@ -3848,9 +4191,9 @@
 			}
 		},
 		"@eslint-community/regexpp": {
-			"version": "4.5.1",
-			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.1.tgz",
-			"integrity": "sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ=="
+			"version": "4.6.1",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.6.1.tgz",
+			"integrity": "sha512-O7x6dMstWLn2ktjcoiNLDkAGG2EjveHL+Vvc+n0fXumkJYAcSqcVYKtwDU+hDZ0uDUsnUagSYaZrOLAYE8un1A=="
 		},
 		"@eslint/eslintrc": {
 			"version": "2.1.0",
@@ -4006,34 +4349,101 @@
 			"integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw=="
 		},
 		"@typescript-eslint/eslint-plugin": {
-			"version": "5.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.60.0.tgz",
-			"integrity": "sha512-78B+anHLF1TI8Jn/cD0Q00TBYdMgjdOn980JfAVa9yw5sop8nyTfVOQAv6LWywkOGLclDBtv5z3oxN4w7jxyNg==",
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.2.0.tgz",
+			"integrity": "sha512-rClGrMuyS/3j0ETa1Ui7s6GkLhfZGKZL3ZrChLeAiACBE/tRc1wq8SNZESUuluxhLj9FkUefRs2l6bCIArWBiQ==",
+			"devOptional": true,
 			"requires": {
-				"@eslint-community/regexpp": "^4.4.0",
-				"@typescript-eslint/scope-manager": "5.60.0",
-				"@typescript-eslint/type-utils": "5.60.0",
-				"@typescript-eslint/utils": "5.60.0",
+				"@eslint-community/regexpp": "^4.5.1",
+				"@typescript-eslint/scope-manager": "6.2.0",
+				"@typescript-eslint/type-utils": "6.2.0",
+				"@typescript-eslint/utils": "6.2.0",
+				"@typescript-eslint/visitor-keys": "6.2.0",
 				"debug": "^4.3.4",
-				"grapheme-splitter": "^1.0.4",
-				"ignore": "^5.2.0",
+				"graphemer": "^1.4.0",
+				"ignore": "^5.2.4",
+				"natural-compare": "^1.4.0",
 				"natural-compare-lite": "^1.4.0",
-				"semver": "^7.3.7",
-				"tsutils": "^3.21.0"
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
 			},
 			"dependencies": {
+				"@typescript-eslint/scope-manager": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.2.0.tgz",
+					"integrity": "sha512-1ZMNVgm5nnHURU8ZSJ3snsHzpFeNK84rdZjluEVBGNu7jDymfqceB3kdIZ6A4xCfEFFhRIB6rF8q/JIqJd2R0Q==",
+					"devOptional": true,
+					"requires": {
+						"@typescript-eslint/types": "6.2.0",
+						"@typescript-eslint/visitor-keys": "6.2.0"
+					}
+				},
+				"@typescript-eslint/types": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.2.0.tgz",
+					"integrity": "sha512-1nRRaDlp/XYJQLvkQJG5F3uBTno5SHPT7XVcJ5n1/k2WfNI28nJsvLakxwZRNY5spuatEKO7d5nZWsQpkqXwBA==",
+					"devOptional": true
+				},
+				"@typescript-eslint/typescript-estree": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.2.0.tgz",
+					"integrity": "sha512-Mts6+3HQMSM+LZCglsc2yMIny37IhUgp1Qe8yJUYVyO6rHP7/vN0vajKu3JvHCBIy8TSiKddJ/Zwu80jhnGj1w==",
+					"devOptional": true,
+					"requires": {
+						"@typescript-eslint/types": "6.2.0",
+						"@typescript-eslint/visitor-keys": "6.2.0",
+						"debug": "^4.3.4",
+						"globby": "^11.1.0",
+						"is-glob": "^4.0.3",
+						"semver": "^7.5.4",
+						"ts-api-utils": "^1.0.1"
+					}
+				},
+				"@typescript-eslint/utils": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.2.0.tgz",
+					"integrity": "sha512-RCFrC1lXiX1qEZN8LmLrxYRhOkElEsPKTVSNout8DMzf8PeWoQG7Rxz2SadpJa3VSh5oYKGwt7j7X/VRg+Y3OQ==",
+					"devOptional": true,
+					"requires": {
+						"@eslint-community/eslint-utils": "^4.4.0",
+						"@types/json-schema": "^7.0.12",
+						"@types/semver": "^7.5.0",
+						"@typescript-eslint/scope-manager": "6.2.0",
+						"@typescript-eslint/types": "6.2.0",
+						"@typescript-eslint/typescript-estree": "6.2.0",
+						"semver": "^7.5.4"
+					}
+				},
+				"@typescript-eslint/visitor-keys": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.2.0.tgz",
+					"integrity": "sha512-QbaYUQVKKo9bgCzpjz45llCfwakyoxHetIy8CAvYCtd16Zu1KrpzNHofwF8kGkpPOxZB2o6kz+0nqH8ZkIzuoQ==",
+					"devOptional": true,
+					"requires": {
+						"@typescript-eslint/types": "6.2.0",
+						"eslint-visitor-keys": "^3.4.1"
+					}
+				},
+				"eslint-visitor-keys": {
+					"version": "3.4.1",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
+					"integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
+					"devOptional": true
+				},
 				"lru-cache": {
 					"version": "6.0.0",
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
 					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+					"devOptional": true,
 					"requires": {
 						"yallist": "^4.0.0"
 					}
 				},
 				"semver": {
-					"version": "7.5.3",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-					"integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+					"version": "7.5.4",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+					"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+					"devOptional": true,
 					"requires": {
 						"lru-cache": "^6.0.0"
 					}
@@ -4041,19 +4451,95 @@
 				"yallist": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+					"devOptional": true
 				}
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "5.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.60.0.tgz",
-			"integrity": "sha512-jBONcBsDJ9UoTWrARkRRCgDz6wUggmH5RpQVlt7BimSwaTkTjwypGzKORXbR4/2Hqjk9hgwlon2rVQAjWNpkyQ==",
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.2.0.tgz",
+			"integrity": "sha512-igVYOqtiK/UsvKAmmloQAruAdUHihsOCvplJpplPZ+3h4aDkC/UKZZNKgB6h93ayuYLuEymU3h8nF1xMRbh37g==",
+			"devOptional": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "5.60.0",
-				"@typescript-eslint/types": "5.60.0",
-				"@typescript-eslint/typescript-estree": "5.60.0",
+				"@typescript-eslint/scope-manager": "6.2.0",
+				"@typescript-eslint/types": "6.2.0",
+				"@typescript-eslint/typescript-estree": "6.2.0",
+				"@typescript-eslint/visitor-keys": "6.2.0",
 				"debug": "^4.3.4"
+			},
+			"dependencies": {
+				"@typescript-eslint/scope-manager": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.2.0.tgz",
+					"integrity": "sha512-1ZMNVgm5nnHURU8ZSJ3snsHzpFeNK84rdZjluEVBGNu7jDymfqceB3kdIZ6A4xCfEFFhRIB6rF8q/JIqJd2R0Q==",
+					"devOptional": true,
+					"requires": {
+						"@typescript-eslint/types": "6.2.0",
+						"@typescript-eslint/visitor-keys": "6.2.0"
+					}
+				},
+				"@typescript-eslint/types": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.2.0.tgz",
+					"integrity": "sha512-1nRRaDlp/XYJQLvkQJG5F3uBTno5SHPT7XVcJ5n1/k2WfNI28nJsvLakxwZRNY5spuatEKO7d5nZWsQpkqXwBA==",
+					"devOptional": true
+				},
+				"@typescript-eslint/typescript-estree": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.2.0.tgz",
+					"integrity": "sha512-Mts6+3HQMSM+LZCglsc2yMIny37IhUgp1Qe8yJUYVyO6rHP7/vN0vajKu3JvHCBIy8TSiKddJ/Zwu80jhnGj1w==",
+					"devOptional": true,
+					"requires": {
+						"@typescript-eslint/types": "6.2.0",
+						"@typescript-eslint/visitor-keys": "6.2.0",
+						"debug": "^4.3.4",
+						"globby": "^11.1.0",
+						"is-glob": "^4.0.3",
+						"semver": "^7.5.4",
+						"ts-api-utils": "^1.0.1"
+					}
+				},
+				"@typescript-eslint/visitor-keys": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.2.0.tgz",
+					"integrity": "sha512-QbaYUQVKKo9bgCzpjz45llCfwakyoxHetIy8CAvYCtd16Zu1KrpzNHofwF8kGkpPOxZB2o6kz+0nqH8ZkIzuoQ==",
+					"devOptional": true,
+					"requires": {
+						"@typescript-eslint/types": "6.2.0",
+						"eslint-visitor-keys": "^3.4.1"
+					}
+				},
+				"eslint-visitor-keys": {
+					"version": "3.4.1",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
+					"integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
+					"devOptional": true
+				},
+				"lru-cache": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+					"devOptional": true,
+					"requires": {
+						"yallist": "^4.0.0"
+					}
+				},
+				"semver": {
+					"version": "7.5.4",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+					"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+					"devOptional": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				},
+				"yallist": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+					"devOptional": true
+				}
 			}
 		},
 		"@typescript-eslint/scope-manager": {
@@ -4066,14 +4552,103 @@
 			}
 		},
 		"@typescript-eslint/type-utils": {
-			"version": "5.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.60.0.tgz",
-			"integrity": "sha512-X7NsRQddORMYRFH7FWo6sA9Y/zbJ8s1x1RIAtnlj6YprbToTiQnM6vxcMu7iYhdunmoC0rUWlca13D5DVHkK2g==",
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.2.0.tgz",
+			"integrity": "sha512-DnGZuNU2JN3AYwddYIqrVkYW0uUQdv0AY+kz2M25euVNlujcN2u+rJgfJsBFlUEzBB6OQkUqSZPyuTLf2bP5mw==",
+			"devOptional": true,
 			"requires": {
-				"@typescript-eslint/typescript-estree": "5.60.0",
-				"@typescript-eslint/utils": "5.60.0",
+				"@typescript-eslint/typescript-estree": "6.2.0",
+				"@typescript-eslint/utils": "6.2.0",
 				"debug": "^4.3.4",
-				"tsutils": "^3.21.0"
+				"ts-api-utils": "^1.0.1"
+			},
+			"dependencies": {
+				"@typescript-eslint/scope-manager": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.2.0.tgz",
+					"integrity": "sha512-1ZMNVgm5nnHURU8ZSJ3snsHzpFeNK84rdZjluEVBGNu7jDymfqceB3kdIZ6A4xCfEFFhRIB6rF8q/JIqJd2R0Q==",
+					"devOptional": true,
+					"requires": {
+						"@typescript-eslint/types": "6.2.0",
+						"@typescript-eslint/visitor-keys": "6.2.0"
+					}
+				},
+				"@typescript-eslint/types": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.2.0.tgz",
+					"integrity": "sha512-1nRRaDlp/XYJQLvkQJG5F3uBTno5SHPT7XVcJ5n1/k2WfNI28nJsvLakxwZRNY5spuatEKO7d5nZWsQpkqXwBA==",
+					"devOptional": true
+				},
+				"@typescript-eslint/typescript-estree": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.2.0.tgz",
+					"integrity": "sha512-Mts6+3HQMSM+LZCglsc2yMIny37IhUgp1Qe8yJUYVyO6rHP7/vN0vajKu3JvHCBIy8TSiKddJ/Zwu80jhnGj1w==",
+					"devOptional": true,
+					"requires": {
+						"@typescript-eslint/types": "6.2.0",
+						"@typescript-eslint/visitor-keys": "6.2.0",
+						"debug": "^4.3.4",
+						"globby": "^11.1.0",
+						"is-glob": "^4.0.3",
+						"semver": "^7.5.4",
+						"ts-api-utils": "^1.0.1"
+					}
+				},
+				"@typescript-eslint/utils": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.2.0.tgz",
+					"integrity": "sha512-RCFrC1lXiX1qEZN8LmLrxYRhOkElEsPKTVSNout8DMzf8PeWoQG7Rxz2SadpJa3VSh5oYKGwt7j7X/VRg+Y3OQ==",
+					"devOptional": true,
+					"requires": {
+						"@eslint-community/eslint-utils": "^4.4.0",
+						"@types/json-schema": "^7.0.12",
+						"@types/semver": "^7.5.0",
+						"@typescript-eslint/scope-manager": "6.2.0",
+						"@typescript-eslint/types": "6.2.0",
+						"@typescript-eslint/typescript-estree": "6.2.0",
+						"semver": "^7.5.4"
+					}
+				},
+				"@typescript-eslint/visitor-keys": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.2.0.tgz",
+					"integrity": "sha512-QbaYUQVKKo9bgCzpjz45llCfwakyoxHetIy8CAvYCtd16Zu1KrpzNHofwF8kGkpPOxZB2o6kz+0nqH8ZkIzuoQ==",
+					"devOptional": true,
+					"requires": {
+						"@typescript-eslint/types": "6.2.0",
+						"eslint-visitor-keys": "^3.4.1"
+					}
+				},
+				"eslint-visitor-keys": {
+					"version": "3.4.1",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
+					"integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
+					"devOptional": true
+				},
+				"lru-cache": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+					"devOptional": true,
+					"requires": {
+						"yallist": "^4.0.0"
+					}
+				},
+				"semver": {
+					"version": "7.5.4",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+					"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+					"devOptional": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				},
+				"yallist": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+					"devOptional": true
+				}
 			}
 		},
 		"@typescript-eslint/types": {
@@ -4754,28 +5329,13 @@
 				}
 			}
 		},
-		"eslint-plugin-es": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-4.1.0.tgz",
-			"integrity": "sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==",
+		"eslint-plugin-es-x": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.2.0.tgz",
+			"integrity": "sha512-9dvv5CcvNjSJPqnS5uZkqb3xmbeqRLnvXKK7iI5+oK/yTusyc46zbBZKENGsOfojm/mKfszyZb+wNqNPAPeGXA==",
 			"requires": {
-				"eslint-utils": "^2.0.0",
-				"regexpp": "^3.0.0"
-			},
-			"dependencies": {
-				"eslint-utils": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-					"integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
-					"requires": {
-						"eslint-visitor-keys": "^1.1.0"
-					}
-				},
-				"eslint-visitor-keys": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-					"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ=="
-				}
+				"@eslint-community/eslint-utils": "^4.1.2",
+				"@eslint-community/regexpp": "^4.6.0"
 			}
 		},
 		"eslint-plugin-import": {
@@ -4819,26 +5379,26 @@
 			}
 		},
 		"eslint-plugin-jest": {
-			"version": "27.2.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.2.2.tgz",
-			"integrity": "sha512-euzbp06F934Z7UDl5ZUaRPLAc9MKjh0rMPERrHT7UhlCEwgb25kBj37TvMgWeHZVkR5I9CayswrpoaqZU1RImw==",
+			"version": "27.2.3",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.2.3.tgz",
+			"integrity": "sha512-sRLlSCpICzWuje66Gl9zvdF6mwD5X86I4u55hJyFBsxYOsBCmT5+kSUjf+fkFWVMMgpzNEupjW8WzUqi83hJAQ==",
 			"requires": {
 				"@typescript-eslint/utils": "^5.10.0"
 			}
 		},
 		"eslint-plugin-n": {
-			"version": "15.7.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.7.0.tgz",
-			"integrity": "sha512-jDex9s7D/Qial8AGVIHq4W7NswpUD5DPDL2RH8Lzd9EloWUuvUkHfv4FRLMipH5q2UtyurorBkPeNi1wVWNh3Q==",
+			"version": "16.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-16.0.1.tgz",
+			"integrity": "sha512-CDmHegJN0OF3L5cz5tATH84RPQm9kG+Yx39wIqIwPR2C0uhBGMWfbbOtetR83PQjjidA5aXMu+LEFw1jaSwvTA==",
 			"requires": {
+				"@eslint-community/eslint-utils": "^4.4.0",
 				"builtins": "^5.0.1",
-				"eslint-plugin-es": "^4.1.0",
-				"eslint-utils": "^3.0.0",
-				"ignore": "^5.1.1",
-				"is-core-module": "^2.11.0",
+				"eslint-plugin-es-x": "^7.1.0",
+				"ignore": "^5.2.4",
+				"is-core-module": "^2.12.1",
 				"minimatch": "^3.1.2",
-				"resolve": "^1.22.1",
-				"semver": "^7.3.8"
+				"resolve": "^1.22.2",
+				"semver": "^7.5.3"
 			},
 			"dependencies": {
 				"lru-cache": {
@@ -4877,14 +5437,6 @@
 			"requires": {
 				"esrecurse": "^4.3.0",
 				"estraverse": "^4.1.1"
-			}
-		},
-		"eslint-utils": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-			"integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-			"requires": {
-				"eslint-visitor-keys": "^2.0.0"
 			}
 		},
 		"eslint-visitor-keys": {
@@ -5152,11 +5704,6 @@
 			"requires": {
 				"get-intrinsic": "^1.1.3"
 			}
-		},
-		"grapheme-splitter": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-			"integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="
 		},
 		"graphemer": {
 			"version": "1.4.0",
@@ -5549,7 +6096,8 @@
 		"natural-compare-lite": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
-			"integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g=="
+			"integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
+			"devOptional": true
 		},
 		"node-releases": {
 			"version": "2.0.12",
@@ -5701,11 +6249,6 @@
 				"define-properties": "^1.2.0",
 				"functions-have-names": "^1.2.3"
 			}
-		},
-		"regexpp": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-			"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg=="
 		},
 		"resolve": {
 			"version": "1.22.2",
@@ -5915,6 +6458,13 @@
 			"requires": {
 				"is-number": "^7.0.0"
 			}
+		},
+		"ts-api-utils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.1.tgz",
+			"integrity": "sha512-lC/RGlPmwdrIBFTX59wwNzqh7aR2otPNPR/5brHZm/XKFYKsfqxihXUe9pU3JI+3vGkl+vyCoNNnPhJn3aLK1A==",
+			"devOptional": true,
+			"requires": {}
 		},
 		"tsconfig-paths": {
 			"version": "3.14.2",

--- a/package.json
+++ b/package.json
@@ -7,21 +7,23 @@
 		"prettier-check": "eslint --print-config .eslintrc.js | eslint-config-prettier-check"
 	},
 	"peerDependencies": {
+		"@typescript-eslint/eslint-plugin": "^5.0.0 || ^6.0.0",
+		"@typescript-eslint/parser": "^5.0.0 || ^6.0.0",
 		"eslint": "^7 || ^8"
 	},
 	"dependencies": {
 		"@babel/core": "^7.17.7",
 		"@babel/eslint-parser": "^7.17.0",
-		"@typescript-eslint/eslint-plugin": "^5.14.0",
-		"@typescript-eslint/parser": "^5.14.0",
 		"eslint-config-prettier": "^8.5.0",
 		"eslint-config-standard": "^17.0.0-0 || ^17",
 		"eslint-plugin-import": "^2.25.4",
-		"eslint-plugin-jest": "^27.0.2",
-		"eslint-plugin-n": "^15.0.0",
+		"eslint-plugin-jest": "^27.2.3",
+		"eslint-plugin-n": "^16.0.0",
 		"eslint-plugin-promise": "^6.0.0"
 	},
 	"devDependencies": {
+		"@typescript-eslint/eslint-plugin": "6.2.0",
+		"@typescript-eslint/parser": "6.2.0",
 		"eslint": "8.45.0",
 		"tape": "5.6.6",
 		"typescript": "5.1.6"


### PR DESCRIPTION
This PR is to update the node versions and to loosen some of the required deps and move them to the peerDependencies.

Node 14 is dead.
https://nodejs.dev/en/about/releases/
Bumped version of node to 16.
16 should be removed soon as it is EoL.

This change is needed as consumers of this package may have different versions of the packages now, allowing for rolling updates to consumers.